### PR TITLE
Silence the first 407.status-3ware-raid periodic run

### DIFF
--- a/sysutils/tw_cli/files/407.status-3ware-raid.in
+++ b/sysutils/tw_cli/files/407.status-3ware-raid.in
@@ -57,7 +57,7 @@ case "$daily_status_3ware_raid_enable" in
 	case "$daily_status_3ware_raid_persist_alarms" in
 	[Yy][Ee][Ss])
 		if test ! -f ${alarms_log}.today; then
-			touch ${alarms_log}.today
+			echo > ${alarms_log}.today
 		fi
 		mv -f ${alarms_log}.today ${alarms_log}.yesterday
 		${tw_cli} alarms > ${alarms_log}.today


### PR DESCRIPTION
- tw_cli outputs a single newline if there are no alarms
  (https://bugs.freenas.org/issues/3799)
