### PR TITLE
Update devel/libconfuse to 3.2.1

### DIFF
--- a/devel/libconfuse/Makefile
+++ b/devel/libconfuse/Makefile
@@ -2,11 +2,13 @@
 # $FreeBSD$
 
 PORTNAME=	libconfuse
-PORTVERSION=	2.7
-PORTREVISION=	2
+DISTVERSION=	3.2.1
 CATEGORIES=	devel
-MASTER_SITES=	SAVANNAH/confuse
-DISTNAME=	confuse-${PORTVERSION}
+
+USE_GITHUB=		yes
+GH_ACCOUNT=		martinh
+GH_PROJECT=		libconfuse
+GH_TAGNAME=		v3.2.1
 
 MAINTAINER=	otis@freebsd.sk
 COMMENT=	Configuration file parsing library
@@ -16,7 +18,7 @@ LICENSE=	ISCL
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS=	--disable-nls --enable-shared
 INSTALL_TARGET=	install-strip
-USES=		iconv pathfix pkgconfig libtool
+USES=		autoreconf iconv pathfix pkgconfig libtool
 USE_LDCONFIG=	yes
 
 .include <bsd.port.mk>

--- a/devel/libconfuse/distinfo
+++ b/devel/libconfuse/distinfo
@@ -1,2 +1,2 @@
-SHA256 (confuse-2.7.tar.gz) = e32574fd837e950778dac7ade40787dd2259ef8e28acd6ede6847ca895c88778
-SIZE (confuse-2.7.tar.gz) = 517272
+SHA256 (martinh-libconfuse-3.2.1-v3.2.1_GH0.tar.gz) = 2eff8e3c300c4ed1d67fdb13f9d31a72a68e31874b4640db15334305bc40cebd
+SIZE (martinh-libconfuse-3.2.1-v3.2.1_GH0.tar.gz) = 116801

--- a/devel/libconfuse/pkg-plist
+++ b/devel/libconfuse/pkg-plist
@@ -1,6 +1,6 @@
 include/confuse.h
 lib/libconfuse.a
 lib/libconfuse.so
-lib/libconfuse.so.0
-lib/libconfuse.so.0.0.0
+lib/libconfuse.so.2
+lib/libconfuse.so.2.0.0
 libdata/pkgconfig/libconfuse.pc


### PR DESCRIPTION
This is necessary to build https://github.com/troglobit/inadyn to resolve https://bugs.freenas.org/issues/7493