### PR TITLE
Update libhyve-remote to 0.1.4.

### DIFF
--- a/devel/libhyve-remote/Makefile
+++ b/devel/libhyve-remote/Makefile
@@ -1,7 +1,7 @@
-# $FreeBSD: head/devel/libhyve-remote/Makefile 452277 2017-10-17 14:01:48Z araujo $
+# $FreeBSD: head/devel/libhyve-remote/Makefile 455245 2017-12-01 02:41:58Z araujo $
 
 PORTNAME=	libhyve-remote
-PORTVERSION=	0.1.3
+PORTVERSION=	0.1.4
 CATEGORIES=	devel
 
 MAINTAINER=	araujo@FreeBSD.org
@@ -21,7 +21,7 @@ LDFLAGS+=	-L${LOCALBASE}/lib
 PLIST_FILES=	${HEADER_FILES} \
 		${LIB_FILES}
 
-HEADER_FILES=	include/libhyverem/hyverem.h 	\
+HEADER_FILES=	include/libhyverem/hyverem.h	\
 		include/libhyverem/rfbsrv.h	\
 		include/libhyverem/libcheck.h	\
 		include/libhyverem/vncserver.h

--- a/devel/libhyve-remote/distinfo
+++ b/devel/libhyve-remote/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1508231978
-SHA256 (araujobsd-libhyve-remote-0.1.3_GH0.tar.gz) = 3b4f5e9ab27206fb78cf76629bf771bfb4426c0041b1af73fa612b4bb3641428
-SIZE (araujobsd-libhyve-remote-0.1.3_GH0.tar.gz) = 11649
+TIMESTAMP = 1512070234
+SHA256 (araujobsd-libhyve-remote-0.1.4_GH0.tar.gz) = 6b9e3d7f0faac5909717320474e29427987d920a065098ab4b0c9192bdbcb08e
+SIZE (araujobsd-libhyve-remote-0.1.4_GH0.tar.gz) = 11739


### PR DESCRIPTION
Fixes:
    2017-09-20 01:27 Marcelo Araujo o - Explicit include header in /usr/local/include.
    2017-09-20 01:30 Marcelo Araujo o - Revert bhyve-patch section on Makefile.
    2017-09-20 01:33 Marcelo Araujo o - Don't build the examples by default.
    2017-09-20 11:37 Marcelo Araujo o Explicitly add another headers path.
    2017-11-30 10:48 Marcelo Araujo o [master] {origin/master} {origin/HEAD} Bind the port to an IPv4 address. If we want bind to all, we can just use 0.0.0.0.