### PR TITLE
Add vimillipede

### DIFF
--- a/net/Makefile
+++ b/net/Makefile
@@ -1428,6 +1428,7 @@
     SUBDIR += vblade
     SUBDIR += vde
     SUBDIR += vde2
+    SUBDIR += viamillipede
     SUBDIR += vinagre
     SUBDIR += vino
     SUBDIR += vmware-vsphere-cli

--- a/net/viamillipede/LICENSE
+++ b/net/viamillipede/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, ash
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/net/viamillipede/Makefile
+++ b/net/viamillipede/Makefile
@@ -1,0 +1,26 @@
+# $FreeBSD$
+
+PORTNAME=	viamillipede
+PORTVERSION=	1.0
+CATEGORIES=	cad
+MASTER_SITES=	https://github.com/agokhale/viamillipede/
+
+MAINTAINER=	ash_ports@aeria.net
+COMMENT=	parallel TCP for pipe transport
+
+LICENSE=	BSD
+
+USE_GITHUB= 	yes
+GH_ACCOUNT=	agokhale
+GH_TAGNAME=	v0.5
+
+BINS=		viamillipede
+
+.PHONY= bad_ideas
+bad_ideas: Makefile
+	rm distinfo
+	sudo make fetch 
+	make makesum
+
+.include <bsd.port.mk>
+

--- a/net/viamillipede/README.md
+++ b/net/viamillipede/README.md
@@ -1,0 +1,2 @@
+# freebsd-port-net-viamillipede
+ports scaffolding for porting freebsd back to freebsd

--- a/net/viamillipede/distinfo
+++ b/net/viamillipede/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1518642072
+SHA256 (agokhale-viamillipede-1.0-v0.5_GH0.tar.gz) = 2733752da950340d78fd2be7507f091641aa1325284dab4f9d7be475796a5e20
+SIZE (agokhale-viamillipede-1.0-v0.5_GH0.tar.gz) = 22717

--- a/net/viamillipede/pkg-descr
+++ b/net/viamillipede/pkg-descr
@@ -1,0 +1,8 @@
+WWW: https://github.com/agokhale/viamillipede
+viamillipede - Paralel TCP transport for pipes
+Viamillipede is client and server program built to improve network 
+pipe transport using multiple TCP sessions.  It multiplexes a single
+ network pipe into multiple TCP con nectons and then terminates the
+connections into a pipe transparently on another host.  
+It is similar to the simplest mode of remote pipe transparency of 
+Netcat with the parallelism from iperf

--- a/net/viamillipede/pkg-plist
+++ b/net/viamillipede/pkg-plist
@@ -1,0 +1,2 @@
+bin/viamillipede
+man/man1/viamillipede.1.gz


### PR DESCRIPTION
Viamillipede is client and server program built to improve network pipe transport using multiple TCP sessions. It multiplexes a single network pipe into multiple TCP connectons and then terminates the connections into a pipe transparently on another host. It is similar to the simplest mode of remote pipe transparency of Netcat with the parallelism from iperf.
https://github.com/agokhale/viamillipede