### PR TITLE
 - Update to 0.1.4.2.

### DIFF
--- a/devel/libhyve-remote/Makefile
+++ b/devel/libhyve-remote/Makefile
@@ -1,8 +1,7 @@
 # $FreeBSD: head/devel/libhyve-remote/Makefile 455701 2017-12-07 09:41:00Z araujo $
 
 PORTNAME=	libhyve-remote
-PORTVERSION=	0.1.4.1
-PORTREVISION=	1
+PORTVERSION=	0.1.4.2
 CATEGORIES=	devel
 
 MAINTAINER=	araujo@FreeBSD.org

--- a/devel/libhyve-remote/distinfo
+++ b/devel/libhyve-remote/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1520447091
-SHA256 (freenas-libhyve-remote-0.1.4.1_GH0.tar.gz) = cf086f6a2c6f43730e74f98eac8cb8b009a6f0332c5344bfa8a0a12e4518d14b
-SIZE (freenas-libhyve-remote-0.1.4.1_GH0.tar.gz) = 11581
+TIMESTAMP = 1532343222
+SHA256 (freenas-libhyve-remote-0.1.4.2_GH0.tar.gz) = 0f92dcb0bf2e72d3142b0cddf990ae3e0d74dbc4c9a9b0f0805990549d6332e4
+SIZE (freenas-libhyve-remote-0.1.4.2_GH0.tar.gz) = 11529


### PR DESCRIPTION
Changelog:
- Remove double free.
On vnc_init_server() we free already the struct server_softc *sc,
we don't need free it on bhyve/vncserver.c. This was probably the
root cause of a SIGBUS.

Ticket: #37842, #37786 and possible #34747