### PR TITLE
tkt-57021: - Update sysutils/uefi-edk2-bhyve to 0.2.

### DIFF
--- a/sysutils/uefi-edk2-bhyve/Makefile
+++ b/sysutils/uefi-edk2-bhyve/Makefile
@@ -1,11 +1,12 @@
-# $FreeBSD$
+# $FreeBSD: head/sysutils/uefi-edk2-bhyve/Makefile 484389 2018-11-07 06:39:56Z araujo $
 
 PORTNAME=	uefi-edk2-bhyve
-PORTVERSION=	20160704
-PORTREVISION=	2
+DISTVERSIONPREFIX=	v
+DISTVERSION=	0.2
+PORTEPOCH=	1
 CATEGORIES=	sysutils
 
-MAINTAINER=	fabian.freyer@physik.tu-berlin.de
+MAINTAINER=	araujo@FreeBSD.org
 COMMENT?=	UEFI-EDK2 firmware for bhyve
 
 LICENSE=	BSD2CLAUSE
@@ -20,7 +21,6 @@ USE_GCC=	4.8
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	uefi-edk2
-GH_TAGNAME=	a36132939e259df79b16699c03c6f1d63c7454b9
 
 PLIST_FILES=	${PREFIX}/share/uefi-firmware/BHYVE_UEFI${PLIST_SUFFIX}.fd
 
@@ -81,3 +81,4 @@ do-install:
 		${STAGEDIR}${PREFIX}/share/uefi-firmware/BHYVE_UEFI${PLIST_SUFFIX}.fd
 
 .include <bsd.port.mk>
+RUN_DEPENDS:=	${RUN_DEPENDS:Ngcc*}

--- a/sysutils/uefi-edk2-bhyve/distinfo
+++ b/sysutils/uefi-edk2-bhyve/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1467621762
-SHA256 (freebsd-uefi-edk2-20160704-a36132939e259df79b16699c03c6f1d63c7454b9_GH0.tar.gz) = 4a98c17a5ff3eb7d631feb6b3e32b019218f85add2a9cfda7dcbc084b2ca808b
-SIZE (freebsd-uefi-edk2-20160704-a36132939e259df79b16699c03c6f1d63c7454b9_GH0.tar.gz) = 31009361
+TIMESTAMP = 1541047623
+SHA256 (freebsd-uefi-edk2-v0.2_GH0.tar.gz) = 886c443f9d2deacdfee33c2794d8692c10e65960cdefe0e523babdcb04c386f2
+SIZE (freebsd-uefi-edk2-v0.2_GH0.tar.gz) = 30981874


### PR DESCRIPTION
Changelog:
- Enable OvmfPkg/VirtioScsiDxe.
- Extend _PRT tables to cover all possible PCI slots and INT lines.