### PR TITLE
- Update sysutils/uefi-edk2-bhyve to 0.2.

### DIFF
--- a/sysutils/uefi-edk2-bhyve/Makefile
+++ b/sysutils/uefi-edk2-bhyve/Makefile
@@ -1,12 +1,12 @@
-# $FreeBSD$
+# $FreeBSD: head/sysutils/uefi-edk2-bhyve/Makefile 484389 2018-11-07 06:39:56Z araujo $
 
 PORTNAME=	uefi-edk2-bhyve
 DISTVERSIONPREFIX=	v
-DISTVERSION=	0.1
+DISTVERSION=	0.2
 PORTEPOCH=	1
 CATEGORIES=	sysutils
 
-MAINTAINER=	fabian.freyer@physik.tu-berlin.de
+MAINTAINER=	araujo@FreeBSD.org
 COMMENT?=	UEFI-EDK2 firmware for bhyve
 
 LICENSE=	BSD2CLAUSE

--- a/sysutils/uefi-edk2-bhyve/distinfo
+++ b/sysutils/uefi-edk2-bhyve/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1524894604
-SHA256 (freebsd-uefi-edk2-v0.1_GH0.tar.gz) = 63cb24712a01cc58ea7f7a7a5635bb29ca8be1db512e27ea5978099382996dae
-SIZE (freebsd-uefi-edk2-v0.1_GH0.tar.gz) = 30979281
+TIMESTAMP = 1541047623
+SHA256 (freebsd-uefi-edk2-v0.2_GH0.tar.gz) = 886c443f9d2deacdfee33c2794d8692c10e65960cdefe0e523babdcb04c386f2
+SIZE (freebsd-uefi-edk2-v0.2_GH0.tar.gz) = 30981874


### PR DESCRIPTION
Changelog:
- Enable OvmfPkg/VirtioScsiDxe.
- Extend _PRT tables to cover all possible PCI slots and INT lines.