### PR TITLE
tkt-56607: Skip mounts marked MNT_IGNORE for df

### DIFF
--- a/net-mgmt/collectd5/Makefile
+++ b/net-mgmt/collectd5/Makefile
@@ -20,7 +20,7 @@ LIB_DEPENDS=	libltdl.so:devel/libltdl
 USES=		autoreconf gmake libtool pkgconfig shebangfix tar:bzip2
 GNU_CONFIGURE=	yes
 
-OPTIONS_DEFINE=		CGI DEBUG GCRYPT LIBDTRACE LIBZFS LOGSTASH VIRT
+OPTIONS_DEFINE=		CGI DEBUG GCRYPT LIBDTRACE LOGSTASH VIRT
 OPTIONS_GROUP=		INPUT OUTPUT
 OPTIONS_GROUP_OUTPUT=	KAFKA MONGODB NOTIFYDESKTOP NOTIFYEMAIL RIEMANN RRDTOOL \
 			TSDB
@@ -41,7 +41,6 @@ IPMI_DESC=		Enable OpenIPMI plugin
 JSON_DESC=		Enable JSON plugins
 KAFKA_DESC=		Enable write_kafka plugin
 LIBDTRACE_DESC=	Build with LibDTrace
-LIBZFS_DESC=	Build with LibZFS
 LOGSTASH_DESC=		Enable log_logstash plugin (requires json)
 MEMCACHEC_DESC=		Enable memcachec plugin
 MODBUS_DESC=		Enable modbus plugin

--- a/net-mgmt/collectd5/Makefile
+++ b/net-mgmt/collectd5/Makefile
@@ -1,12 +1,11 @@
 # Created by: Matt Peterson <matt@peterson.org>
-# $FreeBSD: head/net-mgmt/collectd5/Makefile 436572 2017-03-21 08:26:58Z glebius $
+# $FreeBSD$
 
 PORTNAME=	collectd
 PORTVERSION=	5.7.2
 PORTREVISION=	3
 CATEGORIES=	net-mgmt
-MASTER_SITES=	https://collectd.org/files/ \
-		http://collectd.org/files/
+MASTER_SITES=	https://storage.googleapis.com/collectd-tarballs/
 PKGNAMESUFFIX=	5
 
 MAINTAINER=	ports@bsdserwis.com
@@ -14,8 +13,6 @@ COMMENT=	Systems & network statistics collection daemon
 
 LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
-
-LIB_DEPENDS=	libltdl.so:devel/libltdl
 
 USES=		autoreconf gmake libtool pkgconfig shebangfix tar:bzip2
 GNU_CONFIGURE=	yes
@@ -226,7 +223,8 @@ REDIS_LIB_DEPENDS=		libhiredis.so:databases/hiredis
 REDIS_CONFIGURE_ENABLE=		redis write_redis
 REDIS_CONFIGURE_WITH=		libhiredis=${LOCALBASE}
 
-RIEMANN_LIB_DEPENDS=		libriemann-client.so:net-mgmt/riemann-c-client
+RIEMANN_LIB_DEPENDS=		libriemann-client.so:net-mgmt/riemann-c-client \
+				libltdl.so:devel/libltdl
 RIEMANN_CONFIGURE_ENABLE=	write_riemann
 
 ROUTEROS_LIB_DEPENDS=		librouteros.so:net/librouteros \
@@ -342,19 +340,16 @@ CONFIGURE_ARGS+=--enable-aggregation \
 INSTALL_TARGET=	install-strip
 SHEBANG_FILES=	contrib/collection.cgi
 
-INSTALL_TARGET=	install-strip
-SHEBANG_FILES=	contrib/collection.cgi
-
 post-patch:
 	@${REINPLACE_CMD} 's/-Werror//' \
-		${WRKSRC}/configure.ac ${WRKSRC}/src/Makefile.am \
-		${WRKSRC}/src/libcollectdclient/Makefile.am
+		${WRKSRC}/configure.ac 
 	@${REINPLACE_CMD} \
 		-e 's;@prefix@/var/;/var/;' \
 		-e 's;/var/lib/;/var/db/;' \
 		-e 's;@localstatedir@/lib/;/var/db/;' \
 		${WRKSRC}/src/collectd.conf.in \
-		${WRKSRC}/src/collectd.conf.5
+		${WRKSRC}/src/collectd.conf.5 \
+		${WRKSRC}/src/collectd.conf.pod
 	@${REINPLACE_CMD} \
 		-e 's;/etc/collection\.conf;${WWWDIR}/collection.conf;' \
 		${WRKSRC}/contrib/collection.cgi

--- a/net-mgmt/collectd5/files/patch-configure.ac
+++ b/net-mgmt/collectd5/files/patch-configure.ac
@@ -27,19 +27,6 @@
  fi
  
  AC_CHECK_FUNCS(strptime, [have_strptime="yes"], [have_strptime="no"])
-@@ -1070,10 +1070,10 @@ fi
- 
- # Check for timegm {{{
- 
--# These checks need -Werror because implicit function declarations are only a
-+# These checks need  because implicit function declarations are only a
- # warning ...
- SAVE_CFLAGS="$CFLAGS"
--CFLAGS="$CFLAGS -Werror"
-+CFLAGS="$CFLAGS "
- 
- AC_CACHE_CHECK([for timegm],
-   [c_cv_have_timegm],
 @@ -1923,6 +1923,7 @@ if test "x$with_kstat" = "xyes"
  then
  	AC_CHECK_LIB(kstat, kstat_open, [with_kstat="yes"], [with_kstat="no (libkstat not found)"], [])

--- a/net-mgmt/collectd5/files/patch-configure.ac
+++ b/net-mgmt/collectd5/files/patch-configure.ac
@@ -1,4 +1,4 @@
---- configure.ac.orig	2017-01-23 07:53:57 UTC
+--- configure.ac.orig	2017-06-06 18:13:54 UTC
 +++ configure.ac
 @@ -185,7 +185,7 @@ then
  fi
@@ -9,7 +9,7 @@
  AC_SUBST(pkgconfigdir)
  
  # Check for standards compliance mode
-@@ -876,7 +876,7 @@ SAVE_CFLAGS="$CFLAGS"
+@@ -882,7 +882,7 @@ SAVE_CFLAGS="$CFLAGS"
  # Emulate behavior of src/Makefile.am
  if test "x$GCC" = "xyes"
  then
@@ -18,7 +18,7 @@
  fi
  
  AC_CACHE_CHECK([for strtok_r],
-@@ -1003,7 +1003,7 @@ AC_CHECK_FUNCS(getutxent, [have_getutxen
+@@ -1009,7 +1009,7 @@ AC_CHECK_FUNCS(getutxent, [have_getutxen
  if test "x$GCC" = "xyes"
  then
  	SAVE_CFLAGS="$CFLAGS"
@@ -27,7 +27,20 @@
  fi
  
  AC_CHECK_FUNCS(strptime, [have_strptime="yes"], [have_strptime="no"])
-@@ -1831,6 +1831,7 @@ if test "x$with_kstat" = "xyes"
+@@ -1070,10 +1070,10 @@ fi
+ 
+ # Check for timegm {{{
+ 
+-# These checks need -Werror because implicit function declarations are only a
++# These checks need  because implicit function declarations are only a
+ # warning ...
+ SAVE_CFLAGS="$CFLAGS"
+-CFLAGS="$CFLAGS -Werror"
++CFLAGS="$CFLAGS "
+ 
+ AC_CACHE_CHECK([for timegm],
+   [c_cv_have_timegm],
+@@ -1923,6 +1923,7 @@ if test "x$with_kstat" = "xyes"
  then
  	AC_CHECK_LIB(kstat, kstat_open, [with_kstat="yes"], [with_kstat="no (libkstat not found)"], [])
  fi
@@ -35,7 +48,7 @@
  if test "x$with_kstat" = "xyes"
  then
  	AC_CHECK_LIB(devinfo, di_init, [with_devinfo="yes"], [with_devinfo="no (not found)"], [])
-@@ -1840,6 +1841,8 @@ if test "x$with_kstat" = "xyes"
+@@ -1932,6 +1933,8 @@ if test "x$with_kstat" = "xyes"
  then
  	AC_DEFINE(HAVE_LIBKSTAT, 1,
  		  [Define to 1 if you have the 'kstat' library (-lkstat)])
@@ -44,7 +57,7 @@
  fi
  AM_CONDITIONAL(BUILD_WITH_LIBKSTAT, test "x$with_kstat" = "xyes")
  AM_CONDITIONAL(BUILD_WITH_LIBDEVINFO, test "x$with_devinfo" = "xyes")
-@@ -3225,8 +3228,8 @@ AC_ARG_WITH(libmongoc, [AS_HELP_STRING([
+@@ -3317,8 +3320,8 @@ AC_ARG_WITH(libmongoc, [AS_HELP_STRING([
  	 with_libmongoc="no"
   else
  	 with_libmongoc="yes"
@@ -55,7 +68,7 @@
   fi; fi
  ],
  [with_libmongoc="yes"])
-@@ -3243,7 +3246,7 @@ then
+@@ -3335,7 +3338,7 @@ then
  	then
  		AC_MSG_NOTICE([libmongoc CPPFLAGS: $LIBMONGOC_CPPFLAGS])
  	fi
@@ -64,7 +77,7 @@
  	[with_libmongoc="yes"],
  	[with_libmongoc="no ('mongo.h' not found)"],
  [#if HAVE_STDINT_H
-@@ -3259,7 +3262,7 @@ then
+@@ -3351,7 +3354,7 @@ then
  	then
  		AC_MSG_NOTICE([libmongoc LDFLAGS: $LIBMONGOC_LDFLAGS])
  	fi
@@ -73,7 +86,7 @@
  	[with_libmongoc="yes"],
  	[with_libmongoc="no (symbol 'mongo_run_command' not found)"])
  fi
-@@ -4045,7 +4048,7 @@ then
+@@ -4137,7 +4140,7 @@ then
  	SAVE_LIBS="$LIBS"
  	# trigger an error if Perl_load_module*() uses __attribute__nonnull__(3)
  	# (see issues #41 and #42)
@@ -82,7 +95,7 @@
  	LIBS="$LIBS $PERL_LIBS"
  
  	AC_CACHE_CHECK([for broken Perl_load_module()],
-@@ -5407,6 +5410,137 @@ fi
+@@ -5499,6 +5502,66 @@ fi
  AM_CONDITIONAL(BUILD_WITH_LIBYAJL, test "x$with_libyajl" = "xyes")
  # }}}
  
@@ -146,81 +159,10 @@
 +AM_CONDITIONAL(BUILD_WITH_LIBDTRACE, test "x$with_libdtrace" = "xyes")
 +# }}}
 +
-+# --with-libzfs {{{
-+with_libzfs_cppflags=""
-+with_libzfs_ldflags=""
-+AC_ARG_WITH(libzfs, [AS_HELP_STRING([--with-libzfs@<:@=PREFIX@:>@], [Path to libzfs.])],
-+[
-+	if test "x$withval" = "xyes"
-+	then
-+		with_libzfs_cppflags="\
-+-DNEED_SOLARIS_BOOLEAN=1 \
-+-I /usr/src/cddl/contrib/opensolaris/lib/libzpool/common \
-+-I /usr/src/cddl/compat/opensolaris/include \
-+-I /usr/src/cddl/compat/opensolaris/lib/libumem \
-+-I /usr/src/sys/cddl/compat/opensolaris \
-+-I /usr/src/cddl/contrib/opensolaris/head \
-+-I /usr/src/cddl/contrib/opensolaris/lib/libuutil/common \
-+-I /usr/src/cddl/contrib/opensolaris/lib/libzfs/common \
-+-I /usr/src/cddl/contrib/opensolaris/lib/libzfs_core/common \
-+-I /usr/src/cddl/contrib/opensolaris/lib/libumem/common \
-+-I /usr/src/cddl/contrib/opensolaris/lib/libnvpair \
-+-I /usr/src/sys/cddl/contrib/opensolaris/uts/common \
-+-I /usr/src/sys/cddl/contrib/opensolaris/uts/common/fs/zfs \
-+-I /usr/src/sys/cddl/contrib/opensolaris/uts/common/sys \
-+-I /usr/src/sys/cddl/contrib/opensolaris/common/zfs \
-+"
-+		with_libzfs_ldflags="-lgeom -luutil -lzfs_core -lzfs"
-+		with_libzfs="yes"
-+	else
-+		with_libzfs="no"
-+	fi
-+],
-+[
-+	with_libzfs="no"
-+])
-+if test "x$with_libzfs" = "xyes"
-+then
-+	SAVE_CPPFLAGS="$CPPFLAGS"
-+	SAVE_LDFLAGS="$LDFLAGS"
-+
-+	CPPFLAGS="$CPPFLAGS $with_libzfs_cppflags"
-+	LDFLAGS="$LDFLAGS $with_libzfs_ldflags"
-+
-+	AC_CHECK_LIB(zfs, libzfs_init,
-+	[
-+		AC_DEFINE(HAVE_LIBZFS, 1, [Define to 1 if you have the zfs library (-lzfs).])
-+	], [with_libzfs="no (libzfs not found)"])
-+
-+	CPPFLAGS="$SAVE_CPPFLAGS"
-+	LDFLAGS="$SAVE_LDFLAGS"
-+fi
-+if test "x$with_libzfs" = "xyes"
-+then
-+	SAVE_CPPFLAGS="$CPPFLAGS"
-+	CPPFLAGS="$CPPFLAGS $with_libzfs_cppflags"
-+
-+	AC_CHECK_HEADERS(libzfs.h,
-+	[
-+		AC_DEFINE(HAVE_LIBZFS_H, 1, [Define to 1 if you have the <libzfs.h> header file.])
-+	], [with_libzfs="no (libzfs.h not found)"])
-+
-+	CPPFLAGS="$SAVE_CPPFLAGS"
-+fi
-+if test "x$with_libzfs" = "xyes"
-+then
-+	BUILD_WITH_LIBZFS_CPPFLAGS="$with_libzfs_cppflags"
-+	BUILD_WITH_LIBZFS_LDFLAGS="$with_libzfs_ldflags"
-+	AC_SUBST(BUILD_WITH_LIBZFS_CPPFLAGS)
-+	AC_SUBST(BUILD_WITH_LIBZFS_LDFLAGS)
-+fi
-+AM_CONDITIONAL(BUILD_WITH_LIBZFS, test "x$with_libzfs" = "xyes")
-+# }}}
-+
  # --with-mic {{{
  with_mic_cflags="-I/opt/intel/mic/sysmgmt/sdk/include"
  with_mic_ldpath="-L/opt/intel/mic/sysmgmt/sdk/lib/Linux"
-@@ -5479,8 +5613,8 @@ AC_ARG_WITH(libvarnish, [AS_HELP_STRING(
+@@ -5571,8 +5634,8 @@ AC_ARG_WITH(libvarnish, [AS_HELP_STRING(
  	else if test -d "$with_libvarnish/lib"
  	then
  		AC_MSG_NOTICE([Not checking for libvarnish: Manually configured])
@@ -231,7 +173,7 @@
  		with_libvarnish="yes"
  	fi; fi; fi
  ],
-@@ -5912,7 +6046,7 @@ collectd features:])
+@@ -6004,7 +6067,7 @@ collectd features:])
  AC_COLLECTD([debug],     [enable],  [feature], [debugging])
  AC_COLLECTD([daemon],    [disable], [feature], [daemon mode])
  AC_COLLECTD([getifaddrs],[enable],  [feature], [getifaddrs under Linux])
@@ -240,7 +182,7 @@
  
  dependency_warning="no"
  dependency_error="no"
-@@ -5930,6 +6064,7 @@ plugin_cpufreq="no"
+@@ -6022,6 +6085,7 @@ plugin_cpufreq="no"
  plugin_cpusleep="no"
  plugin_curl_json="no"
  plugin_curl_xml="no"
@@ -248,7 +190,7 @@
  plugin_df="no"
  plugin_disk="no"
  plugin_drbd="no"
-@@ -5938,6 +6073,7 @@ plugin_entropy="no"
+@@ -6030,6 +6094,7 @@ plugin_entropy="no"
  plugin_ethstat="no"
  plugin_fhcount="no"
  plugin_fscache="no"
@@ -256,7 +198,7 @@
  plugin_gps="no"
  plugin_grpc="no"
  plugin_hugepages="no"
-@@ -5951,6 +6087,7 @@ plugin_log_logstash="no"
+@@ -6043,6 +6108,7 @@ plugin_log_logstash="no"
  plugin_memory="no"
  plugin_multimeter="no"
  plugin_nfs="no"
@@ -264,7 +206,7 @@
  plugin_numa="no"
  plugin_perl="no"
  plugin_pinba="no"
-@@ -5974,6 +6111,7 @@ plugin_wireless="no"
+@@ -6066,6 +6132,7 @@ plugin_wireless="no"
  plugin_write_prometheus="no"
  plugin_xencpu="no"
  plugin_zfs_arc="no"
@@ -272,7 +214,7 @@
  plugin_zone="no"
  plugin_zookeeper="no"
  
-@@ -6059,8 +6197,12 @@ fi
+@@ -6151,8 +6218,12 @@ fi
  
  if test "x$ac_system" = "xFreeBSD"
  then
@@ -285,7 +227,7 @@
  fi
  
  
-@@ -6088,6 +6230,7 @@ then
+@@ -6180,6 +6251,7 @@ then
  	plugin_processes="yes"
  	plugin_uptime="yes"
  	plugin_zfs_arc="yes"
@@ -293,7 +235,7 @@
  	plugin_zone="yes"
  fi
  
-@@ -6387,10 +6530,12 @@ AC_PLUGIN([contextswitch],       [$plugi
+@@ -6479,10 +6551,12 @@ AC_PLUGIN([contextswitch],       [$plugi
  AC_PLUGIN([cpu],                 [$plugin_cpu],             [CPU usage statistics])
  AC_PLUGIN([cpufreq],             [$plugin_cpufreq],         [CPU frequency statistics])
  AC_PLUGIN([cpusleep],            [$plugin_cpusleep],        [CPU sleep statistics])
@@ -306,7 +248,7 @@
  AC_PLUGIN([dbi],                 [$with_libdbi],            [General database statistics])
  AC_PLUGIN([df],                  [$plugin_df],              [Filesystem usage statistics])
  AC_PLUGIN([disk],                [$plugin_disk],            [Disk usage statistics])
-@@ -6404,6 +6549,7 @@ AC_PLUGIN([exec],                [yes], 
+@@ -6496,6 +6570,7 @@ AC_PLUGIN([exec],                [yes], 
  AC_PLUGIN([fhcount],             [$plugin_fhcount],         [File handles statistics])
  AC_PLUGIN([filecount],           [yes],                     [Count files in directories])
  AC_PLUGIN([fscache],             [$plugin_fscache],         [fscache statistics])
@@ -314,7 +256,7 @@
  AC_PLUGIN([gmond],               [$with_libganglia],        [Ganglia plugin])
  AC_PLUGIN([gps],                 [$plugin_gps],             [GPS plugin])
  AC_PLUGIN([grpc],                [$plugin_grpc],            [gRPC plugin])
-@@ -6443,6 +6589,7 @@ AC_PLUGIN([netapp],              [$with_
+@@ -6535,6 +6610,7 @@ AC_PLUGIN([netapp],              [$with_
  AC_PLUGIN([netlink],             [$with_libmnl],            [Enhanced Linux network statistics])
  AC_PLUGIN([network],             [yes],                     [Network communication plugin])
  AC_PLUGIN([nfs],                 [$plugin_nfs],             [NFS statistics])
@@ -322,7 +264,7 @@
  AC_PLUGIN([nginx],               [$with_libcurl],           [nginx statistics])
  AC_PLUGIN([notify_desktop],      [$with_libnotify],         [Desktop notifications])
  AC_PLUGIN([notify_email],        [$with_libesmtp],          [Email notifier])
-@@ -6515,6 +6662,7 @@ AC_PLUGIN([write_tsdb],          [yes], 
+@@ -6607,6 +6683,7 @@ AC_PLUGIN([write_tsdb],          [yes], 
  AC_PLUGIN([xencpu],              [$plugin_xencpu],          [Xen Host CPU usage])
  AC_PLUGIN([xmms],                [$with_libxmms],           [XMMS statistics])
  AC_PLUGIN([zfs_arc],             [$plugin_zfs_arc],         [ZFS ARC statistics])
@@ -330,7 +272,7 @@
  AC_PLUGIN([zone],                [$plugin_zone],            [Solaris container statistics])
  AC_PLUGIN([zookeeper],           [yes],                     [Zookeeper statistics])
  
-@@ -6683,8 +6831,8 @@ AM_CFLAGS="-Wall"
+@@ -6775,8 +6852,8 @@ AM_CFLAGS="-Wall"
  AM_CXXFLAGS="-Wall"
  if test "x$enable_werror" != "xno"
  then
@@ -341,15 +283,7 @@
  fi
  AC_SUBST([AM_CFLAGS])
  AC_SUBST([AM_CXXFLAGS])
-@@ -6794,6 +6942,7 @@ AC_MSG_RESULT([    libxenctrl  . . . . .
- AC_MSG_RESULT([    libxml2 . . . . . . . $with_libxml2])
- AC_MSG_RESULT([    libxmms . . . . . . . $with_libxmms])
- AC_MSG_RESULT([    libyajl . . . . . . . $with_libyajl])
-+AC_MSG_RESULT([    libzfs  . . . . . . . $with_libzfs])
- AC_MSG_RESULT([    oracle  . . . . . . . $with_oracle])
- AC_MSG_RESULT([    protobuf-c  . . . . . $have_protoc_c])
- AC_MSG_RESULT([    protoc 3  . . . . . . $have_protoc3])
-@@ -6825,6 +6974,7 @@ AC_MSG_RESULT([    cpu . . . . . . . . .
+@@ -6917,6 +6994,7 @@ AC_MSG_RESULT([    cpu . . . . . . . . .
  AC_MSG_RESULT([    cpufreq . . . . . . . $enable_cpufreq])
  AC_MSG_RESULT([    cpusleep  . . . . . . $enable_cpusleep])
  AC_MSG_RESULT([    csv . . . . . . . . . $enable_csv])
@@ -357,7 +291,7 @@
  AC_MSG_RESULT([    curl  . . . . . . . . $enable_curl])
  AC_MSG_RESULT([    curl_json . . . . . . $enable_curl_json])
  AC_MSG_RESULT([    curl_xml  . . . . . . $enable_curl_xml])
-@@ -6841,6 +6991,7 @@ AC_MSG_RESULT([    exec  . . . . . . . .
+@@ -6933,6 +7011,7 @@ AC_MSG_RESULT([    exec  . . . . . . . .
  AC_MSG_RESULT([    fhcount . . . . . . . $enable_fhcount])
  AC_MSG_RESULT([    filecount . . . . . . $enable_filecount])
  AC_MSG_RESULT([    fscache . . . . . . . $enable_fscache])
@@ -365,7 +299,7 @@
  AC_MSG_RESULT([    gmond . . . . . . . . $enable_gmond])
  AC_MSG_RESULT([    gps . . . . . . . . . $enable_gps])
  AC_MSG_RESULT([    grpc  . . . . . . . . $enable_grpc])
-@@ -6880,6 +7031,7 @@ AC_MSG_RESULT([    netapp  . . . . . . .
+@@ -6972,6 +7051,7 @@ AC_MSG_RESULT([    netapp  . . . . . . .
  AC_MSG_RESULT([    netlink . . . . . . . $enable_netlink])
  AC_MSG_RESULT([    network . . . . . . . $enable_network])
  AC_MSG_RESULT([    nfs . . . . . . . . . $enable_nfs])
@@ -373,7 +307,7 @@
  AC_MSG_RESULT([    nginx . . . . . . . . $enable_nginx])
  AC_MSG_RESULT([    notify_desktop  . . . $enable_notify_desktop])
  AC_MSG_RESULT([    notify_email  . . . . $enable_notify_email])
-@@ -6951,6 +7103,7 @@ AC_MSG_RESULT([    write_tsdb  . . . . .
+@@ -7043,6 +7123,7 @@ AC_MSG_RESULT([    write_tsdb  . . . . .
  AC_MSG_RESULT([    xencpu  . . . . . . . $enable_xencpu])
  AC_MSG_RESULT([    xmms  . . . . . . . . $enable_xmms])
  AC_MSG_RESULT([    zfs_arc . . . . . . . $enable_zfs_arc])

--- a/net-mgmt/collectd5/files/patch-src__Makefile.am
+++ b/net-mgmt/collectd5/files/patch-src__Makefile.am
@@ -1,4 +1,4 @@
---- src/Makefile.am.orig	2017-01-23 07:53:57 UTC
+--- src/Makefile.am.orig	2017-06-06 18:13:54 UTC
 +++ src/Makefile.am
 @@ -292,6 +292,12 @@ contextswitch_la_LIBADD += -lperfstat
  endif
@@ -37,19 +37,7 @@
  if BUILD_PLUGIN_CURL
  pkglib_LTLIBRARIES += curl.la
  curl_la_SOURCES = curl.c \
-@@ -375,6 +389,11 @@ pkglib_LTLIBRARIES += df.la
- df_la_SOURCES = df.c
- df_la_LDFLAGS = $(PLUGIN_LDFLAGS)
- df_la_LIBADD = libmount.la
-+df_la_CPPFLAGS = $(AM_CPPFLAGS)
-+if BUILD_WITH_LIBZFS
-+df_la_CPPFLAGS += $(BUILD_WITH_LIBZFS_CPPFLAGS)
-+df_la_LDFLAGS += $(BUILD_WITH_LIBZFS_LDFLAGS)
-+endif
- endif
- 
- if BUILD_PLUGIN_DISK
-@@ -382,9 +401,9 @@ pkglib_LTLIBRARIES += disk.la
+@@ -382,9 +396,9 @@ pkglib_LTLIBRARIES += disk.la
  disk_la_SOURCES = disk.c
  disk_la_CFLAGS = $(AM_CFLAGS)
  disk_la_LDFLAGS = $(PLUGIN_LDFLAGS)
@@ -61,7 +49,7 @@
  endif
  if BUILD_WITH_LIBDEVINFO
  disk_la_LIBADD += -ldevinfo
-@@ -467,6 +486,13 @@ filecount_la_SOURCES = filecount.c
+@@ -467,6 +481,13 @@ filecount_la_SOURCES = filecount.c
  filecount_la_LDFLAGS = $(PLUGIN_LDFLAGS)
  endif
  
@@ -75,7 +63,7 @@
  if BUILD_PLUGIN_GMOND
  pkglib_LTLIBRARIES += gmond.la
  gmond_la_SOURCES = gmond.c
-@@ -519,7 +545,7 @@ interface_la_CFLAGS += $(BUILD_WITH_LIBS
+@@ -519,7 +540,7 @@ interface_la_CFLAGS += $(BUILD_WITH_LIBS
  interface_la_LIBADD += $(BUILD_WITH_LIBSTATGRAB_LDFLAGS)
  else
  if BUILD_WITH_LIBKSTAT
@@ -84,7 +72,7 @@
  endif
  if BUILD_WITH_LIBDEVINFO
  interface_la_LIBADD += -ldevinfo
-@@ -708,7 +734,7 @@ memory_la_CFLAGS = $(AM_CFLAGS)
+@@ -708,7 +729,7 @@ memory_la_CFLAGS = $(AM_CFLAGS)
  memory_la_LDFLAGS = $(PLUGIN_LDFLAGS)
  memory_la_LIBADD =
  if BUILD_WITH_LIBKSTAT
@@ -93,7 +81,7 @@
  endif
  if BUILD_WITH_LIBDEVINFO
  memory_la_LIBADD += -ldevinfo
-@@ -799,6 +825,17 @@ nfs_la_SOURCES = nfs.c
+@@ -799,6 +820,17 @@ nfs_la_SOURCES = nfs.c
  nfs_la_LDFLAGS = $(PLUGIN_LDFLAGS)
  endif
  
@@ -111,7 +99,7 @@
  if BUILD_PLUGIN_FSCACHE
  pkglib_LTLIBRARIES += fscache.la
  fscache_la_SOURCES = fscache.c
-@@ -1081,7 +1118,7 @@ swap_la_CFLAGS = $(AM_CFLAGS)
+@@ -1081,7 +1113,7 @@ swap_la_CFLAGS = $(AM_CFLAGS)
  swap_la_LDFLAGS = $(PLUGIN_LDFLAGS)
  swap_la_LIBADD =
  if BUILD_WITH_LIBKSTAT
@@ -120,7 +108,7 @@
  endif
  if BUILD_WITH_LIBDEVINFO
  swap_la_LIBADD += -ldevinfo
-@@ -1132,7 +1169,7 @@ if BUILD_PLUGIN_TAPE
+@@ -1132,7 +1164,7 @@ if BUILD_PLUGIN_TAPE
  pkglib_LTLIBRARIES += tape.la
  tape_la_SOURCES = tape.c
  tape_la_LDFLAGS = $(PLUGIN_LDFLAGS)
@@ -129,7 +117,7 @@
  endif
  
  if BUILD_PLUGIN_TARGET_NOTIFICATION
-@@ -1230,7 +1267,7 @@ uptime_la_CFLAGS = $(AM_CFLAGS)
+@@ -1230,7 +1262,7 @@ uptime_la_CFLAGS = $(AM_CFLAGS)
  uptime_la_LDFLAGS = $(PLUGIN_LDFLAGS)
  uptime_la_LIBADD =
  if BUILD_WITH_LIBKSTAT
@@ -138,7 +126,7 @@
  endif
  if BUILD_WITH_PERFSTAT
  uptime_la_LIBADD += -lperfstat
-@@ -1393,7 +1430,19 @@ if BUILD_FREEBSD
+@@ -1393,7 +1425,19 @@ if BUILD_FREEBSD
  zfs_arc_la_LIBADD = -lm
  endif
  if BUILD_SOLARIS
@@ -159,7 +147,7 @@
  endif
  endif
  
-@@ -1501,6 +1550,7 @@ install-exec-hook:
+@@ -1501,6 +1545,7 @@ install-exec-hook:
  	else \
  		$(INSTALL) -m 0640 collectd.conf $(DESTDIR)$(sysconfdir)/collectd.conf; \
  	fi; \

--- a/net-mgmt/collectd5/files/patch-src__df.c
+++ b/net-mgmt/collectd5/files/patch-src__df.c
@@ -1,29 +1,18 @@
 --- src/df.c.orig	2017-06-06 18:13:54 UTC
 +++ src/df.c
-@@ -28,37 +28,26 @@
+@@ -28,6 +28,11 @@
  #include "utils_ignorelist.h"
  #include "utils_mount.h"
  
--#if HAVE_STATVFS
--#if HAVE_SYS_STATVFS_H
--#include <sys/statvfs.h>
--#endif
--#define STATANYFS statvfs
--#define STATANYFS_STR "statvfs"
--#define BLOCKSIZE(s) ((s).f_frsize ? (s).f_frsize : (s).f_bsize)
--#elif HAVE_STATFS
--#if HAVE_SYS_STATFS_H
--#include <sys/statfs.h>
--#endif
--#define STATANYFS statfs
--#define STATANYFS_STR "statfs"
--#define BLOCKSIZE(s) (s).f_bsize
--#else
--#error "No applicable input method."
--#endif
-+#include <sys/param.h>
-+#include <sys/mount.h>
++#ifdef __FreeBSD__
++/* We want to use statfs on FreeBSD, for the mount flags. */
++#undef HAVE_STATVFS
++#endif
 +
+ #if HAVE_STATVFS
+ #if HAVE_SYS_STATVFS_H
+ #include <sys/statvfs.h>
+@@ -48,17 +53,20 @@
  
  static const char *config_keys[] = {
      "Device",         "MountPoint",   "FSType",         "IgnoreSelected",
@@ -45,7 +34,7 @@
  
  static int df_init(void) {
    if (il_device == NULL)
-@@ -67,6 +56,8 @@ static int df_init(void) {
+@@ -67,6 +75,8 @@ static int df_init(void) {
      il_mountpoint = ignorelist_create(1);
    if (il_fstype == NULL)
      il_fstype = ignorelist_create(1);
@@ -54,7 +43,7 @@
  
    return (0);
  }
-@@ -123,6 +114,13 @@ static int df_config(const char *key, co
+@@ -123,6 +133,13 @@ static int df_config(const char *key, co
        values_percentage = 0;
  
      return (0);
@@ -68,39 +57,13 @@
    }
  
    return (-1);
-@@ -147,13 +145,8 @@ __attribute__((nonnull(2))) static void 
- } /* void df_submit_one */
- 
- static int df_read(void) {
--#if HAVE_STATVFS
--  struct statvfs statbuf;
--#elif HAVE_STATFS
--  struct statfs statbuf;
--#endif
--  /* struct STATANYFS statbuf; */
-   cu_mount_t *mnt_list;
-+  struct statfs statbuf;
- 
-   mnt_list = NULL;
-   if (cu_mount_getlist(&mnt_list) == NULL) {
-@@ -163,7 +156,7 @@ static int df_read(void) {
- 
-   for (cu_mount_t *mnt_ptr = mnt_list; mnt_ptr != NULL;
-        mnt_ptr = mnt_ptr->next) {
--    unsigned long long blocksize;
-+    uint64_t blocksize;
-     char disk_name[256];
-     cu_mount_t *dup_ptr;
-     uint64_t blk_free;
-@@ -201,14 +194,26 @@ static int df_read(void) {
-     if (dup_ptr != NULL)
+@@ -202,13 +219,29 @@ static int df_read(void) {
        continue;
  
--    if (STATANYFS(mnt_ptr->dir, &statbuf) < 0) {
+     if (STATANYFS(mnt_ptr->dir, &statbuf) < 0) {
 -      char errbuf[1024];
 -      ERROR(STATANYFS_STR "(%s) failed: %s", mnt_ptr->dir,
 -            sstrerror(errno, errbuf, sizeof(errbuf)));
-+    if (statfs(mnt_ptr->dir, &statbuf) < 0) {
 +      if (log_once == 0 || ignorelist_match(il_errors, mnt_ptr->dir) == 0)
 +      {
 +        if (log_once == 1)
@@ -108,7 +71,7 @@
 +          ignorelist_add(il_errors, mnt_ptr->dir);
 +        }
 +        char errbuf[1024];
-+        ERROR("statfs(%s) failed: %s", mnt_ptr->dir,
++        ERROR(STATANYFS_STR "(%s) failed: %s", mnt_ptr->dir,
 +              sstrerror(errno, errbuf, sizeof(errbuf)));
 +      }
        continue;
@@ -119,62 +82,34 @@
 +      }
      }
  
--    if (!statbuf.f_blocks)
++#ifdef __FreeBSD__
 +    if ((statbuf.f_flags & MNT_IGNORE) || (statbuf.f_blocks == 0))
++#else
+     if (!statbuf.f_blocks)
++#endif
        continue;
  
      if (by_device) {
-@@ -237,25 +242,19 @@ static int df_read(void) {
-       }
-     }
- 
--    blocksize = BLOCKSIZE(statbuf);
-+    blocksize = statbuf.f_bsize;
-+
-+    /*
-+     * Sanity-check for the values in the struct
-+     */
-+
-+    /* Check for negative "available" byes. For example UFS can
-+     * report negative free space for user. Notice. blk_reserved
-+     * will start to diminish after this. */
- 
--/*
-- * Sanity-check for the values in the struct
-- */
--/* Check for negative "available" byes. For example UFS can
-- * report negative free space for user. Notice. blk_reserved
-- * will start to diminish after this. */
--#if HAVE_STATVFS
--    /* Cast and temporary variable are needed to avoid
--     * compiler warnings.
--     * ((struct statvfs).f_bavail is unsigned (POSIX)) */
--    int64_t signed_bavail = (int64_t)statbuf.f_bavail;
--    if (signed_bavail < 0)
--      statbuf.f_bavail = 0;
--#elif HAVE_STATFS
-     if (statbuf.f_bavail < 0)
-       statbuf.f_bavail = 0;
--#endif
-+
-     /* Make sure that f_blocks >= f_bfree >= f_bavail */
-     if (statbuf.f_bfree < statbuf.f_bavail)
-       statbuf.f_bfree = statbuf.f_bavail;
-@@ -295,14 +294,12 @@ static int df_read(void) {
+@@ -295,14 +328,22 @@ static int df_read(void) {
        uint64_t inode_used;
  
        /* Sanity-check for the values in the struct */
--      if (statbuf.f_ffree < statbuf.f_favail)
--        statbuf.f_ffree = statbuf.f_favail;
++#ifndef __FreeBSD__ 
+       if (statbuf.f_ffree < statbuf.f_favail)
+         statbuf.f_ffree = statbuf.f_favail;
++#endif
        if (statbuf.f_files < statbuf.f_ffree)
          statbuf.f_files = statbuf.f_ffree;
  
--      inode_free = (uint64_t)statbuf.f_favail;
--      inode_reserved = (uint64_t)(statbuf.f_ffree - statbuf.f_favail);
--      inode_used = (uint64_t)(statbuf.f_files - statbuf.f_ffree);
++#ifdef __FreeBSD__
 +      inode_free = (uint64_t)statbuf.f_ffree;
 +      inode_reserved = 0;
 +      inode_used = (uint64_t)(statbuf.f_files - inode_free);
++#else
+       inode_free = (uint64_t)statbuf.f_favail;
+       inode_reserved = (uint64_t)(statbuf.f_ffree - statbuf.f_favail);
+       inode_used = (uint64_t)(statbuf.f_files - statbuf.f_ffree);
++#endif
  
        if (values_percentage) {
          if (statbuf.f_files > 0) {

--- a/net-mgmt/collectd5/files/patch-src__df.c
+++ b/net-mgmt/collectd5/files/patch-src__df.c
@@ -1,42 +1,50 @@
---- src/df.c.orig	2017-01-23 07:53:57 UTC
+--- src/df.c.orig	2017-06-06 18:13:54 UTC
 +++ src/df.c
-@@ -46,19 +46,55 @@
- #error "No applicable input method."
- #endif
+@@ -28,37 +28,49 @@
+ #include "utils_ignorelist.h"
+ #include "utils_mount.h"
  
-+#if HAVE_LIBZFS
-+# if HAVE_LIBZFS_H
-+#  include <libzfs.h>
-+# endif
-+# undef STATANYFS
-+# undef STATANYFS_STR
-+# define STATANYFS statzfs
-+# define STATANYFS_STR "statzfs"
-+# undef BLOCKSIZE
-+# define BLOCKSIZE(s) (s).f_bsize
-+struct statzfs {
-+   /* Hacky. This is a copy of struct statvfs */
-+   fsblkcnt_t  f_bavail;   /* Number of blocks */
-+   fsblkcnt_t  f_bfree;
-+   fsblkcnt_t  f_blocks;
-+   fsfilcnt_t  f_favail;   /* Number of files (e.g., inodes) */
-+   fsfilcnt_t  f_ffree;
-+   fsfilcnt_t  f_files;
-+   unsigned long   f_bsize;    /* Size of blocks counted above */
-+   unsigned long   f_flag;
-+   unsigned long   f_frsize;   /* Size of fragments */
-+   unsigned long   f_fsid;     /* Not meaningful */
-+   unsigned long   f_namemax;  /* Same as pathconf(_PC_NAME_MAX) */
+-#if HAVE_STATVFS
+-#if HAVE_SYS_STATVFS_H
+-#include <sys/statvfs.h>
++#include <sys/param.h>
++#include <sys/mount.h>
++#ifdef HAVE_LIBZFS
++#ifdef HAVE_LIBZFS_H
++#include <libzfs.h>
+ #endif
+-#define STATANYFS statvfs
+-#define STATANYFS_STR "statvfs"
+-#define BLOCKSIZE(s) ((s).f_frsize ? (s).f_frsize : (s).f_bsize)
+-#elif HAVE_STATFS
+-#if HAVE_SYS_STATFS_H
+-#include <sys/statfs.h>
+ #endif
+-#define STATANYFS statfs
+-#define STATANYFS_STR "statfs"
+-#define BLOCKSIZE(s) (s).f_bsize
+-#else
+-#error "No applicable input method."
 +
-+   /* ZFS specific data */
-+   uint64_t    f_available;
-+   uint64_t    f_usedbysnapshots;
-+   uint64_t    f_usedbydataset;
-+   uint64_t    f_usedbychildren;
-+   uint64_t    f_usedbyrefreservation;
++
++#ifdef HAVE_LIBZFS
++/* ZFS specific data */
++struct statzfs {
++  uint64_t z_available;
++  uint64_t z_usedbysnapshots;
++  uint64_t z_usedbydataset;
++  uint64_t z_usedbychildren;
++  uint64_t z_usedbyrefreservation;
 +};
 +#endif
 +
++struct mntstat {
++  struct statfs m_fs;
++#ifdef HAVE_LIBZFS
++  struct statzfs m_zfs;
+ #endif
++};
+ 
  static const char *config_keys[] = {
      "Device",         "MountPoint",   "FSType",         "IgnoreSelected",
 -    "ReportByDevice", "ReportInodes", "ValuesAbsolute", "ValuesPercentage"};
@@ -57,7 +65,7 @@
  
  static int df_init(void) {
    if (il_device == NULL)
-@@ -67,6 +103,8 @@
+@@ -67,6 +79,8 @@ static int df_init(void) {
      il_mountpoint = ignorelist_create(1);
    if (il_fstype == NULL)
      il_fstype = ignorelist_create(1);
@@ -66,7 +74,7 @@
  
    return (0);
  }
-@@ -123,11 +161,68 @@
+@@ -123,11 +137,73 @@ static int df_config(const char *key, co
        values_percentage = 0;
  
      return (0);
@@ -82,77 +90,92 @@
    return (-1);
  }
  
-+#if HAVE_LIBZFS
-+int
-+statzfs(const char *restrict path, struct statzfs *restrict buf)
++int mntstat(const char *restrict path, struct mntstat *restrict buf)
 +{
-+   size_t blocksize = 1024;
-+   libzfs_handle_t *libzfsp;
-+   zfs_handle_t *zfsp;
-+   uint64_t available, real_used, total;
-+
-+   if (path == NULL)
-+       return (-1);
-+
-+   if (statvfs(path, (struct statvfs *)buf) < 0)
-+       return (-1);
-+
-+   if ((libzfsp = libzfs_init()) == NULL)
-+       return (-1);
-+
-+   libzfs_print_on_error(libzfsp, B_TRUE);
-+
-+   zfsp = zfs_path_to_zhandle(libzfsp, (char *)path,
-+       ZFS_TYPE_VOLUME|ZFS_TYPE_DATASET|ZFS_TYPE_FILESYSTEM);
-+   if (zfsp == NULL)
-+       return (-1);
-+
-+   buf->f_available = zfs_prop_get_int(zfsp, ZFS_PROP_AVAILABLE);
-+   buf->f_usedbysnapshots = zfs_prop_get_int(zfsp, ZFS_PROP_USEDSNAP);
-+   buf->f_usedbydataset = zfs_prop_get_int(zfsp, ZFS_PROP_USEDDS);
-+   buf->f_usedbychildren = zfs_prop_get_int(zfsp, ZFS_PROP_USEDCHILD);
-+   buf->f_usedbyrefreservation = zfs_prop_get_int(zfsp, ZFS_PROP_USEDREFRESERV);
-+
-+   zfs_close(zfsp);
-+   libzfs_fini(libzfsp);
-+
-+   real_used = buf->f_usedbysnapshots + buf->f_usedbydataset + buf->f_usedbychildren;
-+   total = (real_used + buf->f_available);
-+   available = buf->f_available;
-+
-+   buf->f_bsize = blocksize;
-+   buf->f_blocks = total / blocksize;
-+   buf->f_bfree = available / blocksize;
-+   buf->f_bavail = available / blocksize;
-+
-+   /* Don't support this option when using ZFS */
-+   report_inodes = 0;
-+
-+   return (0);
-+}
++  struct statfs *fsp;
++#ifdef HAVE_LIBZFS
++  struct statzfs *zsp;
++  libzfs_handle_t *libzfsp;
++  zfs_handle_t *zfsp;
++  uint64_t available, real_used, total;
++  size_t blocksize;
 +#endif
++
++  if (path == NULL || buf == NULL)
++    return (-1);
++
++  fsp = &buf->m_fs;
++  if (statfs(path, fsp) < 0)
++    return (-1);
++
++#ifdef HAVE_LIBZFS
++  if ((libzfsp = libzfs_init()) == NULL)
++    return (-1);
++
++  libzfs_print_on_error(libzfsp, B_TRUE);
++
++  zfsp = zfs_path_to_zhandle(libzfsp, (char *)path,
++    ZFS_TYPE_VOLUME|ZFS_TYPE_DATASET|ZFS_TYPE_FILESYSTEM);
++  if (zfsp == NULL)
++    return (-1);
++
++  zsp = &buf->m_zfs;
++  blocksize = fsp->f_bsize = zfs_prop_get_int(zfsp, ZFS_PROP_RECORDSIZE);
++  available = zsp->z_available = zfs_prop_get_int(zfsp, ZFS_PROP_AVAILABLE);
++  zsp->z_usedbysnapshots = zfs_prop_get_int(zfsp, ZFS_PROP_USEDSNAP);
++  zsp->z_usedbydataset = zfs_prop_get_int(zfsp, ZFS_PROP_USEDDS);
++  zsp->z_usedbychildren = zfs_prop_get_int(zfsp, ZFS_PROP_USEDCHILD);
++  zsp->z_usedbyrefreservation = zfs_prop_get_int(zfsp, ZFS_PROP_USEDREFRESERV);
++
++  zfs_close(zfsp);
++  libzfs_fini(libzfsp);
++
++  real_used = zsp->z_usedbysnapshots + zsp->z_usedbydataset + zsp->z_usedbychildren;
++  total = (available + real_used);
++
++  fsp->f_bsize = blocksize;
++  fsp->f_blocks = total / blocksize;
++  fsp->f_bfree = available / blocksize;
++  fsp->f_bavail = available / blocksize;
++
++  /* Don't support this option when using ZFS */
++  report_inodes = 0;
++#endif
++
++  return (0);
++}
 +
  __attribute__((nonnull(2))) static void df_submit_one(char *plugin_instance,
                                                        const char *type,
                                                        const char *type_instance,
-@@ -147,7 +242,9 @@
+@@ -147,13 +223,12 @@ __attribute__((nonnull(2))) static void 
  } /* void df_submit_one */
  
  static int df_read(void) {
 -#if HAVE_STATVFS
-+#if HAVE_LIBZFS
-+  struct statzfs statbuf;
-+#elif HAVE_STATVFS
-   struct statvfs statbuf;
- #elif HAVE_STATFS
-   struct statfs statbuf;
-@@ -202,10 +299,22 @@
+-  struct statvfs statbuf;
+-#elif HAVE_STATFS
+-  struct statfs statbuf;
+-#endif
+-  /* struct STATANYFS statbuf; */
+   cu_mount_t *mnt_list;
++  struct mntstat statbuf;
++  struct statfs *fsp = &statbuf.m_fs;
++#ifdef HAVE_LIBZFS
++  struct statzfs *zsp = &statbuf.m_zfs;
++#endif
+ 
+   mnt_list = NULL;
+   if (cu_mount_getlist(&mnt_list) == NULL) {
+@@ -201,14 +276,26 @@ static int df_read(void) {
+     if (dup_ptr != NULL)
        continue;
  
-     if (STATANYFS(mnt_ptr->dir, &statbuf) < 0) {
+-    if (STATANYFS(mnt_ptr->dir, &statbuf) < 0) {
 -      char errbuf[1024];
 -      ERROR(STATANYFS_STR "(%s) failed: %s", mnt_ptr->dir,
 -            sstrerror(errno, errbuf, sizeof(errbuf)));
++    if (mntstat(mnt_ptr->dir, &statbuf) < 0) {
 +      if (log_once == 0 || ignorelist_match(il_errors, mnt_ptr->dir) == 0)
 +      {
 +        if (log_once == 1)
@@ -160,7 +183,7 @@
 +          ignorelist_add(il_errors, mnt_ptr->dir);
 +        }
 +        char errbuf[1024];
-+        ERROR(STATANYFS_STR "(%s) failed: %s", mnt_ptr->dir,
++        ERROR("mntstat(%s) failed: %s", mnt_ptr->dir,
 +              sstrerror(errno, errbuf, sizeof(errbuf)));
 +      }
        continue;
@@ -171,18 +194,127 @@
 +      }
      }
  
-     if (!statbuf.f_blocks)
-@@ -263,7 +372,13 @@
-       statbuf.f_blocks = statbuf.f_bfree;
+-    if (!statbuf.f_blocks)
++    if ((fsp->f_flags & MNT_IGNORE) || (fsp->f_blocks == 0))
+       continue;
  
-     blk_free = (uint64_t)statbuf.f_bavail;
-+#if HAVE_LIBZFS
-+    blk_reserved = 0;
-+    if (statbuf.f_usedbyrefreservation > 0)
-+      blk_reserved = (uint64_t) statbuf.f_usedbyrefreservation / blocksize;
+     if (by_device) {
+@@ -237,34 +324,33 @@ static int df_read(void) {
+       }
+     }
+ 
+-    blocksize = BLOCKSIZE(statbuf);
++    blocksize = fsp->f_bsize;
++
++    /*
++     * Sanity-check for the values in the struct
++     */
++
++    /* Check for negative "available" byes. For example UFS can
++     * report negative free space for user. Notice. blk_reserved
++     * will start to diminish after this. */
++
++    if (fsp->f_bavail < 0)
++      fsp->f_bavail = 0;
+ 
+-/*
+- * Sanity-check for the values in the struct
+- */
+-/* Check for negative "available" byes. For example UFS can
+- * report negative free space for user. Notice. blk_reserved
+- * will start to diminish after this. */
+-#if HAVE_STATVFS
+-    /* Cast and temporary variable are needed to avoid
+-     * compiler warnings.
+-     * ((struct statvfs).f_bavail is unsigned (POSIX)) */
+-    int64_t signed_bavail = (int64_t)statbuf.f_bavail;
+-    if (signed_bavail < 0)
+-      statbuf.f_bavail = 0;
+-#elif HAVE_STATFS
+-    if (statbuf.f_bavail < 0)
+-      statbuf.f_bavail = 0;
+-#endif
+     /* Make sure that f_blocks >= f_bfree >= f_bavail */
+-    if (statbuf.f_bfree < statbuf.f_bavail)
+-      statbuf.f_bfree = statbuf.f_bavail;
+-    if (statbuf.f_blocks < statbuf.f_bfree)
+-      statbuf.f_blocks = statbuf.f_bfree;
++    if (fsp->f_bfree < fsp->f_bavail)
++      fsp->f_bfree = fsp->f_bavail;
++    if (fsp->f_blocks < fsp->f_bfree)
++      fsp->f_blocks = fsp->f_bfree;
+ 
+-    blk_free = (uint64_t)statbuf.f_bavail;
+-    blk_reserved = (uint64_t)(statbuf.f_bfree - statbuf.f_bavail);
+-    blk_used = (uint64_t)(statbuf.f_blocks - statbuf.f_bfree);
++    blk_free = (uint64_t)fsp->f_bavail;
++#ifdef HAVE_LIBZFS
++    blk_reserved = (zsp->z_usedbyrefreservation > 0) ?
++      (uint64_t) zsp->z_usedbyrefreservation / blocksize : 0;
 +#else
-     blk_reserved = (uint64_t)(statbuf.f_bfree - statbuf.f_bavail);
++    blk_reserved = (uint64_t)(fsp->f_bfree - fsp->f_bavail);
 +#endif
-     blk_used = (uint64_t)(statbuf.f_blocks - statbuf.f_bfree);
++    blk_used = (uint64_t)(fsp->f_blocks - fsp->f_bfree);
  
      if (values_absolute) {
+       df_submit_one(disk_name, "df_complex", "free",
+@@ -276,45 +362,43 @@ static int df_read(void) {
+     }
+ 
+     if (values_percentage) {
+-      if (statbuf.f_blocks > 0) {
++      if (fsp->f_blocks > 0) {
+         df_submit_one(disk_name, "percent_bytes", "free",
+-                      (gauge_t)((float_t)(blk_free) / statbuf.f_blocks * 100));
++                      (gauge_t)((float_t)(blk_free) / fsp->f_blocks * 100));
+         df_submit_one(
+             disk_name, "percent_bytes", "reserved",
+-            (gauge_t)((float_t)(blk_reserved) / statbuf.f_blocks * 100));
++            (gauge_t)((float_t)(blk_reserved) / fsp->f_blocks * 100));
+         df_submit_one(disk_name, "percent_bytes", "used",
+-                      (gauge_t)((float_t)(blk_used) / statbuf.f_blocks * 100));
++                      (gauge_t)((float_t)(blk_used) / fsp->f_blocks * 100));
+       } else
+         return (-1);
+     }
+ 
+     /* inode handling */
+-    if (report_inodes && statbuf.f_files != 0 && statbuf.f_ffree != 0) {
++    if (report_inodes && fsp->f_files != 0 && fsp->f_ffree != 0) {
+       uint64_t inode_free;
+       uint64_t inode_reserved;
+       uint64_t inode_used;
+ 
+       /* Sanity-check for the values in the struct */
+-      if (statbuf.f_ffree < statbuf.f_favail)
+-        statbuf.f_ffree = statbuf.f_favail;
+-      if (statbuf.f_files < statbuf.f_ffree)
+-        statbuf.f_files = statbuf.f_ffree;
++      if (fsp->f_files < fsp->f_ffree)
++        fsp->f_files = fsp->f_ffree;
+ 
+-      inode_free = (uint64_t)statbuf.f_favail;
+-      inode_reserved = (uint64_t)(statbuf.f_ffree - statbuf.f_favail);
+-      inode_used = (uint64_t)(statbuf.f_files - statbuf.f_ffree);
++      inode_free = (uint64_t)fsp->f_ffree;
++      inode_reserved = 0;
++      inode_used = (uint64_t)(fsp->f_files - inode_free);
+ 
+       if (values_percentage) {
+-        if (statbuf.f_files > 0) {
++        if (fsp->f_files > 0) {
+           df_submit_one(
+               disk_name, "percent_inodes", "free",
+-              (gauge_t)((float_t)(inode_free) / statbuf.f_files * 100));
++              (gauge_t)((float_t)(inode_free) / fsp->f_files * 100));
+           df_submit_one(
+               disk_name, "percent_inodes", "reserved",
+-              (gauge_t)((float_t)(inode_reserved) / statbuf.f_files * 100));
++              (gauge_t)((float_t)(inode_reserved) / fsp->f_files * 100));
+           df_submit_one(
+               disk_name, "percent_inodes", "used",
+-              (gauge_t)((float_t)(inode_used) / statbuf.f_files * 100));
++              (gauge_t)((float_t)(inode_used) / fsp->f_files * 100));
+         } else
+           return (-1);
+       }

--- a/net-mgmt/collectd5/files/patch-src__df.c
+++ b/net-mgmt/collectd5/files/patch-src__df.c
@@ -1,49 +1,29 @@
 --- src/df.c.orig	2017-06-06 18:13:54 UTC
 +++ src/df.c
-@@ -28,37 +28,49 @@
+@@ -28,37 +28,26 @@
  #include "utils_ignorelist.h"
  #include "utils_mount.h"
  
 -#if HAVE_STATVFS
 -#if HAVE_SYS_STATVFS_H
 -#include <sys/statvfs.h>
-+#include <sys/param.h>
-+#include <sys/mount.h>
-+#ifdef HAVE_LIBZFS
-+#ifdef HAVE_LIBZFS_H
-+#include <libzfs.h>
- #endif
+-#endif
 -#define STATANYFS statvfs
 -#define STATANYFS_STR "statvfs"
 -#define BLOCKSIZE(s) ((s).f_frsize ? (s).f_frsize : (s).f_bsize)
 -#elif HAVE_STATFS
 -#if HAVE_SYS_STATFS_H
 -#include <sys/statfs.h>
- #endif
+-#endif
 -#define STATANYFS statfs
 -#define STATANYFS_STR "statfs"
 -#define BLOCKSIZE(s) (s).f_bsize
 -#else
 -#error "No applicable input method."
+-#endif
++#include <sys/param.h>
++#include <sys/mount.h>
 +
-+
-+#ifdef HAVE_LIBZFS
-+/* ZFS specific data */
-+struct statzfs {
-+  uint64_t z_available;
-+  uint64_t z_usedbysnapshots;
-+  uint64_t z_usedbydataset;
-+  uint64_t z_usedbychildren;
-+  uint64_t z_usedbyrefreservation;
-+};
-+#endif
-+
-+struct mntstat {
-+  struct statfs m_fs;
-+#ifdef HAVE_LIBZFS
-+  struct statzfs m_zfs;
- #endif
-+};
  
  static const char *config_keys[] = {
      "Device",         "MountPoint",   "FSType",         "IgnoreSelected",
@@ -65,7 +45,7 @@
  
  static int df_init(void) {
    if (il_device == NULL)
-@@ -67,6 +79,8 @@ static int df_init(void) {
+@@ -67,6 +56,8 @@ static int df_init(void) {
      il_mountpoint = ignorelist_create(1);
    if (il_fstype == NULL)
      il_fstype = ignorelist_create(1);
@@ -74,7 +54,7 @@
  
    return (0);
  }
-@@ -123,11 +137,73 @@ static int df_config(const char *key, co
+@@ -123,6 +114,13 @@ static int df_config(const char *key, co
        values_percentage = 0;
  
      return (0);
@@ -88,67 +68,7 @@
    }
  
    return (-1);
- }
- 
-+int mntstat(const char *restrict path, struct mntstat *restrict buf)
-+{
-+  struct statfs *fsp;
-+#ifdef HAVE_LIBZFS
-+  struct statzfs *zsp;
-+  libzfs_handle_t *libzfsp;
-+  zfs_handle_t *zfsp;
-+  uint64_t available, real_used, total;
-+  size_t blocksize;
-+#endif
-+
-+  if (path == NULL || buf == NULL)
-+    return (-1);
-+
-+  fsp = &buf->m_fs;
-+  if (statfs(path, fsp) < 0)
-+    return (-1);
-+
-+#ifdef HAVE_LIBZFS
-+  if ((libzfsp = libzfs_init()) == NULL)
-+    return (-1);
-+
-+  libzfs_print_on_error(libzfsp, B_TRUE);
-+
-+  zfsp = zfs_path_to_zhandle(libzfsp, (char *)path,
-+    ZFS_TYPE_VOLUME|ZFS_TYPE_DATASET|ZFS_TYPE_FILESYSTEM);
-+  if (zfsp == NULL)
-+    return (-1);
-+
-+  zsp = &buf->m_zfs;
-+  blocksize = fsp->f_bsize = zfs_prop_get_int(zfsp, ZFS_PROP_RECORDSIZE);
-+  available = zsp->z_available = zfs_prop_get_int(zfsp, ZFS_PROP_AVAILABLE);
-+  zsp->z_usedbysnapshots = zfs_prop_get_int(zfsp, ZFS_PROP_USEDSNAP);
-+  zsp->z_usedbydataset = zfs_prop_get_int(zfsp, ZFS_PROP_USEDDS);
-+  zsp->z_usedbychildren = zfs_prop_get_int(zfsp, ZFS_PROP_USEDCHILD);
-+  zsp->z_usedbyrefreservation = zfs_prop_get_int(zfsp, ZFS_PROP_USEDREFRESERV);
-+
-+  zfs_close(zfsp);
-+  libzfs_fini(libzfsp);
-+
-+  real_used = zsp->z_usedbysnapshots + zsp->z_usedbydataset + zsp->z_usedbychildren;
-+  total = (available + real_used);
-+
-+  fsp->f_bsize = blocksize;
-+  fsp->f_blocks = total / blocksize;
-+  fsp->f_bfree = available / blocksize;
-+  fsp->f_bavail = available / blocksize;
-+
-+  /* Don't support this option when using ZFS */
-+  report_inodes = 0;
-+#endif
-+
-+  return (0);
-+}
-+
- __attribute__((nonnull(2))) static void df_submit_one(char *plugin_instance,
-                                                       const char *type,
-                                                       const char *type_instance,
-@@ -147,13 +223,12 @@ __attribute__((nonnull(2))) static void 
+@@ -147,13 +145,8 @@ __attribute__((nonnull(2))) static void 
  } /* void df_submit_one */
  
  static int df_read(void) {
@@ -159,15 +79,20 @@
 -#endif
 -  /* struct STATANYFS statbuf; */
    cu_mount_t *mnt_list;
-+  struct mntstat statbuf;
-+  struct statfs *fsp = &statbuf.m_fs;
-+#ifdef HAVE_LIBZFS
-+  struct statzfs *zsp = &statbuf.m_zfs;
-+#endif
++  struct statfs statbuf;
  
    mnt_list = NULL;
    if (cu_mount_getlist(&mnt_list) == NULL) {
-@@ -201,14 +276,26 @@ static int df_read(void) {
+@@ -163,7 +156,7 @@ static int df_read(void) {
+ 
+   for (cu_mount_t *mnt_ptr = mnt_list; mnt_ptr != NULL;
+        mnt_ptr = mnt_ptr->next) {
+-    unsigned long long blocksize;
++    uint64_t blocksize;
+     char disk_name[256];
+     cu_mount_t *dup_ptr;
+     uint64_t blk_free;
+@@ -201,14 +194,26 @@ static int df_read(void) {
      if (dup_ptr != NULL)
        continue;
  
@@ -175,7 +100,7 @@
 -      char errbuf[1024];
 -      ERROR(STATANYFS_STR "(%s) failed: %s", mnt_ptr->dir,
 -            sstrerror(errno, errbuf, sizeof(errbuf)));
-+    if (mntstat(mnt_ptr->dir, &statbuf) < 0) {
++    if (statfs(mnt_ptr->dir, &statbuf) < 0) {
 +      if (log_once == 0 || ignorelist_match(il_errors, mnt_ptr->dir) == 0)
 +      {
 +        if (log_once == 1)
@@ -183,7 +108,7 @@
 +          ignorelist_add(il_errors, mnt_ptr->dir);
 +        }
 +        char errbuf[1024];
-+        ERROR("mntstat(%s) failed: %s", mnt_ptr->dir,
++        ERROR("statfs(%s) failed: %s", mnt_ptr->dir,
 +              sstrerror(errno, errbuf, sizeof(errbuf)));
 +      }
        continue;
@@ -195,16 +120,16 @@
      }
  
 -    if (!statbuf.f_blocks)
-+    if ((fsp->f_flags & MNT_IGNORE) || (fsp->f_blocks == 0))
++    if ((statbuf.f_flags & MNT_IGNORE) || (statbuf.f_blocks == 0))
        continue;
  
      if (by_device) {
-@@ -237,34 +324,33 @@ static int df_read(void) {
+@@ -237,25 +242,19 @@ static int df_read(void) {
        }
      }
  
 -    blocksize = BLOCKSIZE(statbuf);
-+    blocksize = fsp->f_bsize;
++    blocksize = statbuf.f_bsize;
 +
 +    /*
 +     * Sanity-check for the values in the struct
@@ -213,9 +138,6 @@
 +    /* Check for negative "available" byes. For example UFS can
 +     * report negative free space for user. Notice. blk_reserved
 +     * will start to diminish after this. */
-+
-+    if (fsp->f_bavail < 0)
-+      fsp->f_bavail = 0;
  
 -/*
 - * Sanity-check for the values in the struct
@@ -231,90 +153,28 @@
 -    if (signed_bavail < 0)
 -      statbuf.f_bavail = 0;
 -#elif HAVE_STATFS
--    if (statbuf.f_bavail < 0)
--      statbuf.f_bavail = 0;
+     if (statbuf.f_bavail < 0)
+       statbuf.f_bavail = 0;
 -#endif
++
      /* Make sure that f_blocks >= f_bfree >= f_bavail */
--    if (statbuf.f_bfree < statbuf.f_bavail)
--      statbuf.f_bfree = statbuf.f_bavail;
--    if (statbuf.f_blocks < statbuf.f_bfree)
--      statbuf.f_blocks = statbuf.f_bfree;
-+    if (fsp->f_bfree < fsp->f_bavail)
-+      fsp->f_bfree = fsp->f_bavail;
-+    if (fsp->f_blocks < fsp->f_bfree)
-+      fsp->f_blocks = fsp->f_bfree;
- 
--    blk_free = (uint64_t)statbuf.f_bavail;
--    blk_reserved = (uint64_t)(statbuf.f_bfree - statbuf.f_bavail);
--    blk_used = (uint64_t)(statbuf.f_blocks - statbuf.f_bfree);
-+    blk_free = (uint64_t)fsp->f_bavail;
-+#ifdef HAVE_LIBZFS
-+    blk_reserved = (zsp->z_usedbyrefreservation > 0) ?
-+      (uint64_t) zsp->z_usedbyrefreservation / blocksize : 0;
-+#else
-+    blk_reserved = (uint64_t)(fsp->f_bfree - fsp->f_bavail);
-+#endif
-+    blk_used = (uint64_t)(fsp->f_blocks - fsp->f_bfree);
- 
-     if (values_absolute) {
-       df_submit_one(disk_name, "df_complex", "free",
-@@ -276,45 +362,43 @@ static int df_read(void) {
-     }
- 
-     if (values_percentage) {
--      if (statbuf.f_blocks > 0) {
-+      if (fsp->f_blocks > 0) {
-         df_submit_one(disk_name, "percent_bytes", "free",
--                      (gauge_t)((float_t)(blk_free) / statbuf.f_blocks * 100));
-+                      (gauge_t)((float_t)(blk_free) / fsp->f_blocks * 100));
-         df_submit_one(
-             disk_name, "percent_bytes", "reserved",
--            (gauge_t)((float_t)(blk_reserved) / statbuf.f_blocks * 100));
-+            (gauge_t)((float_t)(blk_reserved) / fsp->f_blocks * 100));
-         df_submit_one(disk_name, "percent_bytes", "used",
--                      (gauge_t)((float_t)(blk_used) / statbuf.f_blocks * 100));
-+                      (gauge_t)((float_t)(blk_used) / fsp->f_blocks * 100));
-       } else
-         return (-1);
-     }
- 
-     /* inode handling */
--    if (report_inodes && statbuf.f_files != 0 && statbuf.f_ffree != 0) {
-+    if (report_inodes && fsp->f_files != 0 && fsp->f_ffree != 0) {
-       uint64_t inode_free;
-       uint64_t inode_reserved;
+     if (statbuf.f_bfree < statbuf.f_bavail)
+       statbuf.f_bfree = statbuf.f_bavail;
+@@ -295,14 +294,12 @@ static int df_read(void) {
        uint64_t inode_used;
  
        /* Sanity-check for the values in the struct */
 -      if (statbuf.f_ffree < statbuf.f_favail)
 -        statbuf.f_ffree = statbuf.f_favail;
--      if (statbuf.f_files < statbuf.f_ffree)
--        statbuf.f_files = statbuf.f_ffree;
-+      if (fsp->f_files < fsp->f_ffree)
-+        fsp->f_files = fsp->f_ffree;
+       if (statbuf.f_files < statbuf.f_ffree)
+         statbuf.f_files = statbuf.f_ffree;
  
 -      inode_free = (uint64_t)statbuf.f_favail;
 -      inode_reserved = (uint64_t)(statbuf.f_ffree - statbuf.f_favail);
 -      inode_used = (uint64_t)(statbuf.f_files - statbuf.f_ffree);
-+      inode_free = (uint64_t)fsp->f_ffree;
++      inode_free = (uint64_t)statbuf.f_ffree;
 +      inode_reserved = 0;
-+      inode_used = (uint64_t)(fsp->f_files - inode_free);
++      inode_used = (uint64_t)(statbuf.f_files - inode_free);
  
        if (values_percentage) {
--        if (statbuf.f_files > 0) {
-+        if (fsp->f_files > 0) {
-           df_submit_one(
-               disk_name, "percent_inodes", "free",
--              (gauge_t)((float_t)(inode_free) / statbuf.f_files * 100));
-+              (gauge_t)((float_t)(inode_free) / fsp->f_files * 100));
-           df_submit_one(
-               disk_name, "percent_inodes", "reserved",
--              (gauge_t)((float_t)(inode_reserved) / statbuf.f_files * 100));
-+              (gauge_t)((float_t)(inode_reserved) / fsp->f_files * 100));
-           df_submit_one(
-               disk_name, "percent_inodes", "used",
--              (gauge_t)((float_t)(inode_used) / statbuf.f_files * 100));
-+              (gauge_t)((float_t)(inode_used) / fsp->f_files * 100));
-         } else
-           return (-1);
-       }
+         if (statbuf.f_files > 0) {


### PR DESCRIPTION
MNT_IGNORE is a flag that indicates a filesystem should not be counted by df.
This change teaches the df plugin for collectd to obey it.

The df plugin was designed to support statfs as well as statvfs.  It preferred
statvfs for no apparent reason.  The use of statvfs seems to be discouraged by
the man page, it doesn't appear to provide any additional data over statfs,
and it does not include the `f_flags` field we need to check MNT_IGNORE.  So,
use of statvfs has been removed.  We will always use statfs.

LIBZFS-dependent code is also removed. We have not been using it, and it does not provide any additional metrics. ZFS should report the values we are interested in via statfs().

Ticket: #56607