### PR TITLE
tkt-58185: Update py-netif port

### DIFF
--- a/net/py-netif/Makefile
+++ b/net/py-netif/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	netif
-PORTVERSION=	1.0.20180615
+PORTVERSION=	1.0.20181121
 CATEGORIES=	net python
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
@@ -17,7 +17,7 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}bsd>0:devel/py-bsd@${PY_FLAVOR} \
 USE_GITHUB=     yes
 GH_ACCOUNT=	freenas
 GH_PROJECT=	py-netif
-GH_TAGNAME=	1c657fb
+GH_TAGNAME=	ecbb4ae
 
 USES=		python
 USE_PYTHON=	autoplist distutils cython

--- a/net/py-netif/distinfo
+++ b/net/py-netif/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1529088516
-SHA256 (freenas-py-netif-1.0.20180615-1c657fb_GH0.tar.gz) = e1de3ac5d238a312ecc9274c35364450e9d9cc4973083b76e65848a4a17fa064
-SIZE (freenas-py-netif-1.0.20180615-1c657fb_GH0.tar.gz) = 21815
+TIMESTAMP = 1542750795
+SHA256 (freenas-py-netif-1.0.20181121-ecbb4ae_GH0.tar.gz) = 554c5b8ec39d090802b6dcae8f0b347d8b5a7f205a77e4071bfd4f9dd956e91c
+SIZE (freenas-py-netif-1.0.20181121-ecbb4ae_GH0.tar.gz) = 59882


### PR DESCRIPTION
This commit updates py-netif port to reflect the latest commint in the py-netif repository.
Ticket: #58185