### PR TITLE
Py-netif port bug fix

### DIFF
--- a/net/py-netif/Makefile
+++ b/net/py-netif/Makefile
@@ -21,5 +21,6 @@ GH_TAGNAME=	ecbb4ae
 
 USES=		python
 USE_PYTHON=	autoplist distutils cython
+GNU_CONFIGURE=	yes
 
 .include <bsd.port.mk>


### PR DESCRIPTION
This commit adds support for py-netif port to use GNU Configure when building/installing it.