### PR TITLE
Allow restoring previous versions of streams

### DIFF
--- a/net/samba49/Makefile
+++ b/net/samba49/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}49
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			1
+PORTREVISION=			2	
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -23,6 +23,7 @@ EXTRA_PATCHES+=		 	${PATCHDIR}/0001-add-ix-custom-vfs-modules.patch:-p1
 EXTRA_PATCHES+=		 	${PATCHDIR}/0001-add-support-for-xattrs-larger-than-64k.patch:-p1
 EXTRA_PATCHES+=		 	${PATCHDIR}/0001-add-parameters-for-ha-configuration.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/0001-add-idmap_fruit-backend.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/0001-fix-shadowcopy-streams.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba49/files/0001-fix-shadowcopy-streams.patch
+++ b/net/samba49/files/0001-fix-shadowcopy-streams.patch
@@ -1,0 +1,1225 @@
+Samba bugzilla 13455, 13688
+---
+ selftest/target/Samba3.pm                        |   9 +
+ source3/modules/vfs_error_inject.c               |  19 ++
+ source3/modules/vfs_shadow_copy2.c               | 230 +++++++++++++++++++++--
+ source3/rpc_server/srvsvc/srv_srvsvc_nt.c        |   2 +
+ source3/script/tests/test_shadow_copy_torture.sh | 114 +++++++++++
+ source3/selftest/tests.py                        |   1 +
+ source3/smbd/filename.c                          |  32 +++-
+ source3/smbd/nttrans.c                           |   4 +
+ source3/smbd/open.c                              |   1 +
+ source3/smbd/proto.h                             |   1 +
+ source3/smbd/reply.c                             |  15 ++
+ source3/smbd/smb2_create.c                       |  30 +--
+ source3/smbd/smb2_query_directory.c              |   1 +
+ source3/smbd/trans2.c                            |   8 +
+ source4/torture/smb2/create.c                    | 174 +++++++++++++++++
+ source4/torture/smb2/smb2.c                      |   1 +
+ 16 files changed, 599 insertions(+), 43 deletions(-)
+ create mode 100755 source3/script/tests/test_shadow_copy_torture.sh
+
+diff --git a/selftest/target/Samba3.pm b/selftest/target/Samba3.pm
+index 438cb34..314aae5 100755
+--- a/selftest/target/Samba3.pm
++++ b/selftest/target/Samba3.pm
+@@ -2134,6 +2134,15 @@ sub provision($$$$$$$$$)
+ 	vfs objects = shadow_copy2
+ 	shadow:mountpoint = $shadow_mntdir
+ 	wide links = yes
++
++[shadow_write]
++	path = $shadow_tstdir
++	comment = previous versions snapshots under mount point
++	vfs objects = shadow_copy2 streams_xattr error_inject
++	aio write size = 0
++	error_inject:pwrite = EBADF
++	shadow:mountpoint = $shadow_tstdir
++
+ [dfq]
+ 	path = $shrdir/dfree
+ 	vfs objects = acl_xattr fake_acls xattr_tdb fake_dfq
+diff --git a/source3/modules/vfs_error_inject.c b/source3/modules/vfs_error_inject.c
+index bb5477a..c8c3ea4 100644
+--- a/source3/modules/vfs_error_inject.c
++++ b/source3/modules/vfs_error_inject.c
+@@ -28,6 +28,7 @@ struct unix_error_map {
+ 	int error;
+ } unix_error_map_array[] = {
+ 	{	"ESTALE",	ESTALE	},
++	{	"EBADF",	EBADF	},
+ };
+ 
+ static int find_unix_error_from_string(const char *err_str)
+@@ -88,8 +89,26 @@ static int vfs_error_inject_chdir(vfs_handle_struct *handle,
+ 	return SMB_VFS_NEXT_CHDIR(handle, smb_fname);
+ }
+ 
++static ssize_t vfs_error_inject_pwrite(vfs_handle_struct *handle,
++				       files_struct *fsp,
++				       const void *data,
++				       size_t n,
++				       off_t offset)
++{
++	int error;
++
++	error = inject_unix_error("pwrite", handle);
++	if (error != 0) {
++		errno = error;
++		return -1;
++	}
++
++	return SMB_VFS_NEXT_PWRITE(handle, fsp, data, n, offset);
++}
++
+ static struct vfs_fn_pointers vfs_error_inject_fns = {
+ 	.chdir_fn = vfs_error_inject_chdir,
++	.pwrite_fn = vfs_error_inject_pwrite,
+ };
+ 
+ static_decl_vfs;
+diff --git a/source3/modules/vfs_shadow_copy2.c b/source3/modules/vfs_shadow_copy2.c
+index aa7cd9c..06ef3eb 100644
+--- a/source3/modules/vfs_shadow_copy2.c
++++ b/source3/modules/vfs_shadow_copy2.c
+@@ -36,6 +36,8 @@
+ #include "include/ntioctl.h"
+ #include "util_tdb.h"
+ #include "lib/util_path.h"
++#include "libcli/security/security.h"
++#include "lib/util/tevent_unix.h"
+ 
+ struct shadow_copy2_config {
+ 	char *gmt_format;
+@@ -587,7 +589,8 @@ static bool shadow_copy2_strip_snapshot_internal(TALLOC_CTX *mem_ctx,
+ 					const char *orig_name,
+ 					time_t *ptimestamp,
+ 					char **pstripped,
+-					char **psnappath)
++					char **psnappath,
++					bool *_already_converted)
+ {
+ 	struct tm tm;
+ 	time_t timestamp = 0;
+@@ -608,6 +611,10 @@ static bool shadow_copy2_strip_snapshot_internal(TALLOC_CTX *mem_ctx,
+ 
+ 	DEBUG(10, (__location__ ": enter path '%s'\n", name));
+ 
++	if (_already_converted != NULL) {
++		*_already_converted = false;
++	}
++
+ 	abs_path = make_path_absolute(mem_ctx, priv, name);
+ 	if (abs_path == NULL) {
+ 		ret = false;
+@@ -630,6 +637,9 @@ static bool shadow_copy2_strip_snapshot_internal(TALLOC_CTX *mem_ctx,
+ 	}
+ 
+ 	if (already_converted) {
++		if (_already_converted != NULL) {
++			*_already_converted = true;
++		}
+ 		goto out;
+ 	}
+ 
+@@ -759,9 +769,26 @@ static bool shadow_copy2_strip_snapshot(TALLOC_CTX *mem_ctx,
+ 					orig_name,
+ 					ptimestamp,
+ 					pstripped,
++					NULL,
+ 					NULL);
+ }
+ 
++static bool shadow_copy2_strip_snapshot_converted(TALLOC_CTX *mem_ctx,
++					struct vfs_handle_struct *handle,
++					const char *orig_name,
++					time_t *ptimestamp,
++					char **pstripped,
++					bool *is_converted)
++{
++	return shadow_copy2_strip_snapshot_internal(mem_ctx,
++					handle,
++					orig_name,
++					ptimestamp,
++					pstripped,
++					NULL,
++					is_converted);
++}
++
+ static char *shadow_copy2_find_mount_point(TALLOC_CTX *mem_ctx,
+ 					   vfs_handle_struct *handle)
+ {
+@@ -1119,12 +1146,14 @@ static int shadow_copy2_rename(vfs_handle_struct *handle,
+ 
+ 	if (!shadow_copy2_strip_snapshot_internal(talloc_tos(), handle,
+ 					 smb_fname_src->base_name,
+-					 &timestamp_src, NULL, &snappath_src)) {
++					 &timestamp_src, NULL, &snappath_src,
++					 NULL)) {
+ 		return -1;
+ 	}
+ 	if (!shadow_copy2_strip_snapshot_internal(talloc_tos(), handle,
+ 					 smb_fname_dst->base_name,
+-					 &timestamp_dst, NULL, &snappath_dst)) {
++					 &timestamp_dst, NULL, &snappath_dst,
++					 NULL)) {
+ 		return -1;
+ 	}
+ 	if (timestamp_src != 0) {
+@@ -1163,7 +1192,8 @@ static int shadow_copy2_symlink(vfs_handle_struct *handle,
+ 				link_contents,
+ 				&timestamp_old,
+ 				NULL,
+-				&snappath_old)) {
++				&snappath_old,
++				NULL)) {
+ 		return -1;
+ 	}
+ 	if (!shadow_copy2_strip_snapshot_internal(talloc_tos(),
+@@ -1171,7 +1201,8 @@ static int shadow_copy2_symlink(vfs_handle_struct *handle,
+ 				new_smb_fname->base_name,
+ 				&timestamp_new,
+ 				NULL,
+-				&snappath_new)) {
++				&snappath_new,
++				NULL)) {
+ 		return -1;
+ 	}
+ 	if ((timestamp_old != 0) || (timestamp_new != 0)) {
+@@ -1202,7 +1233,8 @@ static int shadow_copy2_link(vfs_handle_struct *handle,
+ 				old_smb_fname->base_name,
+ 				&timestamp_old,
+ 				NULL,
+-				&snappath_old)) {
++				&snappath_old,
++				NULL)) {
+ 		return -1;
+ 	}
+ 	if (!shadow_copy2_strip_snapshot_internal(talloc_tos(),
+@@ -1210,7 +1242,8 @@ static int shadow_copy2_link(vfs_handle_struct *handle,
+ 				new_smb_fname->base_name,
+ 				&timestamp_new,
+ 				NULL,
+-				&snappath_new)) {
++				&snappath_new,
++				NULL)) {
+ 		return -1;
+ 	}
+ 	if ((timestamp_old != 0) || (timestamp_new != 0)) {
+@@ -1321,21 +1354,63 @@ static int shadow_copy2_fstat(vfs_handle_struct *handle, files_struct *fsp,
+ 			      SMB_STRUCT_STAT *sbuf)
+ {
+ 	time_t timestamp = 0;
++	struct smb_filename *orig_smb_fname = NULL;
++	struct smb_filename vss_smb_fname;
++	struct smb_filename *orig_base_smb_fname = NULL;
++	struct smb_filename vss_base_smb_fname;
++	char *stripped = NULL;
++	int saved_errno = 0;
++	bool ok;
+ 	int ret;
+ 
++	ok = shadow_copy2_strip_snapshot(talloc_tos(), handle,
++					 fsp->fsp_name->base_name,
++					 &timestamp, &stripped);
++	if (!ok) {
++		return -1;
++	}
++
++	if (timestamp == 0) {
++		TALLOC_FREE(stripped);
++		return SMB_VFS_NEXT_FSTAT(handle, fsp, sbuf);
++	}
++
++	vss_smb_fname = *fsp->fsp_name;
++	vss_smb_fname.base_name = shadow_copy2_convert(talloc_tos(),
++						       handle,
++						       stripped,
++						       timestamp);
++	TALLOC_FREE(stripped);
++	if (vss_smb_fname.base_name == NULL) {
++		return -1;
++	}
++
++	orig_smb_fname = fsp->fsp_name;
++	fsp->fsp_name = &vss_smb_fname;
++
++	if (fsp->base_fsp != NULL) {
++		vss_base_smb_fname = *fsp->base_fsp->fsp_name;
++		vss_base_smb_fname.base_name = vss_smb_fname.base_name;
++		orig_base_smb_fname = fsp->base_fsp->fsp_name;
++		fsp->base_fsp->fsp_name = &vss_base_smb_fname;
++	}
++
+ 	ret = SMB_VFS_NEXT_FSTAT(handle, fsp, sbuf);
+-	if (ret == -1) {
+-		return ret;
++	fsp->fsp_name = orig_smb_fname;
++	if (fsp->base_fsp != NULL) {
++		fsp->base_fsp->fsp_name = orig_base_smb_fname;
+ 	}
+-	if (!shadow_copy2_strip_snapshot(talloc_tos(), handle,
+-					 fsp->fsp_name->base_name,
+-					 &timestamp, NULL)) {
+-		return 0;
++	if (ret == -1) {
++		saved_errno = errno;
+ 	}
+-	if (timestamp != 0) {
++
++	if (ret == 0) {
+ 		convert_sbuf(handle, fsp->fsp_name->base_name, sbuf);
+ 	}
+-	return 0;
++	if (saved_errno != 0) {
++		errno = saved_errno;
++	}
++	return ret;
+ }
+ 
+ static int shadow_copy2_open(vfs_handle_struct *handle,
+@@ -1345,15 +1420,27 @@ static int shadow_copy2_open(vfs_handle_struct *handle,
+ 	time_t timestamp = 0;
+ 	char *stripped = NULL;
+ 	char *tmp;
++	bool is_converted = false;
+ 	int saved_errno = 0;
+ 	int ret;
+ 
+-	if (!shadow_copy2_strip_snapshot(talloc_tos(), handle,
++	if (!shadow_copy2_strip_snapshot_converted(talloc_tos(), handle,
+ 					 smb_fname->base_name,
+-					 &timestamp, &stripped)) {
++					 &timestamp, &stripped,
++					 &is_converted)) {
+ 		return -1;
+ 	}
+ 	if (timestamp == 0) {
++		if (is_converted) {
++			/*
++			 * Just pave over the user requested mode and use
++			 * O_RDONLY. Later attempts by the client to write on
++			 * the handle will fail in the pwrite() syscall with
++			 * EINVAL which we carefully map to EROFS. In sum, this
++			 * matches Windows behaviour.
++			 */
++			flags = O_RDONLY;
++		}
+ 		return SMB_VFS_NEXT_OPEN(handle, smb_fname, fsp, flags, mode);
+ 	}
+ 
+@@ -1367,6 +1454,14 @@ static int shadow_copy2_open(vfs_handle_struct *handle,
+ 		return -1;
+ 	}
+ 
++	/*
++	 * Just pave over the user requested mode and use O_RDONLY. Later
++	 * attempts by the client to write on the handle will fail in the
++	 * pwrite() syscall with EINVAL which we carefully map to EROFS. In sum,
++	 * this matches Windows behaviour.
++	 */
++	flags = O_RDONLY;
++
+ 	ret = SMB_VFS_NEXT_OPEN(handle, smb_fname, fsp, flags, mode);
+ 	if (ret == -1) {
+ 		saved_errno = errno;
+@@ -1566,7 +1661,8 @@ static int shadow_copy2_chdir(vfs_handle_struct *handle,
+ 					smb_fname->base_name,
+ 					&timestamp,
+ 					&stripped,
+-					&snappath)) {
++					&snappath,
++					NULL)) {
+ 		return -1;
+ 	}
+ 	if (stripped != NULL) {
+@@ -2855,6 +2951,101 @@ static int shadow_copy2_get_quota(vfs_handle_struct *handle,
+ 	return ret;
+ }
+ 
++static ssize_t shadow_copy2_pwrite(vfs_handle_struct *handle,
++				   files_struct *fsp,
++				   const void *data,
++				   size_t n,
++				   off_t offset)
++{
++	ssize_t nwritten;
++
++	nwritten = SMB_VFS_NEXT_PWRITE(handle, fsp, data, n, offset);
++	if (nwritten == -1) {
++		if (errno == EBADF && fsp->can_write) {
++			errno = EROFS;
++		}
++	}
++
++	return nwritten;
++}
++
++struct shadow_copy2_pwrite_state {
++	vfs_handle_struct *handle;
++	files_struct *fsp;
++	ssize_t ret;
++	struct vfs_aio_state vfs_aio_state;
++};
++
++static void shadow_copy2_pwrite_done(struct tevent_req *subreq);
++
++static struct tevent_req *shadow_copy2_pwrite_send(
++	struct vfs_handle_struct *handle, TALLOC_CTX *mem_ctx,
++	struct tevent_context *ev, struct files_struct *fsp,
++	const void *data, size_t n, off_t offset)
++{
++	struct tevent_req *req = NULL, *subreq = NULL;
++	struct shadow_copy2_pwrite_state *state = NULL;
++
++	req = tevent_req_create(mem_ctx, &state,
++				struct shadow_copy2_pwrite_state);
++	if (req == NULL) {
++		return NULL;
++	}
++	state->handle = handle;
++	state->fsp = fsp;
++
++	subreq = SMB_VFS_NEXT_PWRITE_SEND(state,
++					  ev,
++					  handle,
++					  fsp,
++					  data,
++					  n,
++					  offset);
++	if (tevent_req_nomem(subreq, req)) {
++		return tevent_req_post(req, ev);
++	}
++	tevent_req_set_callback(subreq, shadow_copy2_pwrite_done, req);
++
++	return req;
++}
++
++static void shadow_copy2_pwrite_done(struct tevent_req *subreq)
++{
++	struct tevent_req *req = tevent_req_callback_data(
++		subreq, struct tevent_req);
++	struct shadow_copy2_pwrite_state *state = tevent_req_data(
++		req, struct shadow_copy2_pwrite_state);
++
++	state->ret = SMB_VFS_PWRITE_RECV(subreq, &state->vfs_aio_state);
++	TALLOC_FREE(subreq);
++	if (state->ret == -1) {
++		tevent_req_error(req, state->vfs_aio_state.error);
++		return;
++	}
++
++	tevent_req_done(req);
++}
++
++static ssize_t shadow_copy2_pwrite_recv(struct tevent_req *req,
++					  struct vfs_aio_state *vfs_aio_state)
++{
++	struct shadow_copy2_pwrite_state *state = tevent_req_data(
++		req, struct shadow_copy2_pwrite_state);
++
++	if (tevent_req_is_unix_error(req, &vfs_aio_state->error)) {
++		if ((vfs_aio_state->error == EBADF) &&
++		    state->fsp->can_write)
++		{
++			vfs_aio_state->error = EROFS;
++			errno = EROFS;
++		}
++		return -1;
++	}
++
++	*vfs_aio_state = state->vfs_aio_state;
++	return state->ret;
++}
++
+ static int shadow_copy2_connect(struct vfs_handle_struct *handle,
+ 				const char *service, const char *user)
+ {
+@@ -3217,6 +3408,9 @@ static struct vfs_fn_pointers vfs_shadow_copy2_fns = {
+ 	.setxattr_fn = shadow_copy2_setxattr,
+ 	.chflags_fn = shadow_copy2_chflags,
+ 	.get_real_filename_fn = shadow_copy2_get_real_filename,
++	.pwrite_fn = shadow_copy2_pwrite,
++	.pwrite_send_fn = shadow_copy2_pwrite_send,
++	.pwrite_recv_fn = shadow_copy2_pwrite_recv,
+ 	.connectpath_fn = shadow_copy2_connectpath,
+ };
+ 
+diff --git a/source3/rpc_server/srvsvc/srv_srvsvc_nt.c b/source3/rpc_server/srvsvc/srv_srvsvc_nt.c
+index e1963a4..f90d915 100644
+--- a/source3/rpc_server/srvsvc/srv_srvsvc_nt.c
++++ b/source3/rpc_server/srvsvc/srv_srvsvc_nt.c
+@@ -2363,6 +2363,7 @@ WERROR _srvsvc_NetGetFileSecurity(struct pipes_struct *p,
+ 					r->in.file,
+ 					ucf_flags,
+ 					NULL,
++					NULL,
+ 					&smb_fname);
+ 	if (!NT_STATUS_IS_OK(nt_status)) {
+ 		werr = ntstatus_to_werror(nt_status);
+@@ -2496,6 +2497,7 @@ WERROR _srvsvc_NetSetFileSecurity(struct pipes_struct *p,
+ 					r->in.file,
+ 					ucf_flags,
+ 					NULL,
++					NULL,
+ 					&smb_fname);
+ 	if (!NT_STATUS_IS_OK(nt_status)) {
+ 		werr = ntstatus_to_werror(nt_status);
+diff --git a/source3/script/tests/test_shadow_copy_torture.sh b/source3/script/tests/test_shadow_copy_torture.sh
+new file mode 100755
+index 0000000..3b05fc5
+--- /dev/null
++++ b/source3/script/tests/test_shadow_copy_torture.sh
+@@ -0,0 +1,114 @@
++#!/bin/bash
++#
++# Blackbox test for shadow_copy2 VFS.
++#
++
++if [ $# -lt 7 ]; then
++cat <<EOF
++Usage: test_shadow_copy SERVER SERVER_IP DOMAIN USERNAME PASSWORD WORKDIR SMBTORTURE
++EOF
++exit 1;
++fi
++
++SERVER=${1}
++SERVER_IP=${2}
++DOMAIN=${3}
++USERNAME=${4}
++PASSWORD=${5}
++WORKDIR=${6}
++SMBTORTURE="$VALGRIND ${7}"
++shift 7
++
++incdir=`dirname $0`/../../../testprogs/blackbox
++. $incdir/subunit.sh
++
++SNAPSHOT="@GMT-2015.10.31-19.40.30"
++
++failed=0
++
++# build a hierarchy of files, symlinks, and directories
++build_files()
++{
++    local destdir
++    destdir=$1
++
++    echo "$content" > $destdir/foo
++}
++
++# build a snapshots directory
++build_snapshots()
++{
++    local snapdir
++
++    snapdir=$WORKDIR/.snapshots
++
++    mkdir -p $snapdir
++    mkdir $snapdir/$SNAPSHOT
++
++    build_files $snapdir/$SNAPSHOT
++}
++
++build_stream_on_snapshot()
++{
++    file=$WORKDIR/.snapshots/$SNAPSHOT/foo
++
++    setfattr -n 'user.DosStream.bar:$DATA' -v baz $file || return 1
++}
++
++test_shadow_copy_write()
++{
++    local msg
++
++    msg=$1
++
++    #delete snapshots from previous tests
++    find $WORKDIR -name ".snapshots" -exec rm -rf {} \; 1>/dev/null 2>&1
++    build_snapshots
++
++    testit "writing to shadow copy of a file" \
++	   $SMBTORTURE \
++	   -U$USERNAME%$PASSWORD \
++	   "//$SERVER/shadow_write" \
++	   --option="torture:twrp_file=foo" \
++	   --option="torture:twrp_snapshot=$SNAPSHOT" \
++	   smb2.twrp.write || \
++        failed=`expr $failed + 1`
++}
++
++test_shadow_copy_stream()
++{
++    local msg
++
++    msg=$1
++
++    #delete snapshots from previous tests
++    find $WORKDIR -name ".snapshots" -exec rm -rf {} \; 1>/dev/null 2>&1
++    build_snapshots
++    build_stream_on_snapshot || {
++	subunit_start_test msg
++	subunit_skip_test msg <<EOF
++test_shadow_copy_stream needs an fs with xattrs
++EOF
++	return 0
++    }
++
++    testit "reading stream of a shadow copy of a file" \
++	   $SMBTORTURE \
++	   -U$USERNAME%$PASSWORD \
++	   "//$SERVER/shadow_write" \
++	   --option="torture:twrp_file=foo" \
++	   --option="torture:twrp_stream=bar" \
++	   --option="torture:twrp_stream_size=3" \
++	   --option="torture:twrp_snapshot=$SNAPSHOT" \
++	   smb2.twrp.stream || \
++        failed=`expr $failed + 1`
++}
++
++build_files $WORKDIR
++
++# test open for writing and write behaviour of snapshoted files
++test_shadow_copy_write "write behaviour of snapshoted files"
++
++test_shadow_copy_stream "reading stream of snapshotted file"
++
++exit $failed
+diff --git a/source3/selftest/tests.py b/source3/selftest/tests.py
+index 2763b1b..33bd0e1 100755
+--- a/source3/selftest/tests.py
++++ b/source3/selftest/tests.py
+@@ -275,6 +275,7 @@ for env in ["fileserver"]:
+     plantestsuite("samba3.blackbox.offline (%s)" % env, env, [os.path.join(samba3srcdir, "script/tests/test_offline.sh"), '$SERVER', '$SERVER_IP', '$DOMAIN', '$USERNAME', '$PASSWORD', '$LOCAL_PATH/offline', smbclient3])
+     plantestsuite("samba3.blackbox.shadow_copy2 NT1 (%s)" % env, env, [os.path.join(samba3srcdir, "script/tests/test_shadow_copy.sh"), '$SERVER', '$SERVER_IP', '$DOMAIN', '$USERNAME', '$PASSWORD', '$LOCAL_PATH/shadow', smbclient3, '-m', 'NT1'])
+     plantestsuite("samba3.blackbox.shadow_copy2 SMB3 (%s)" % env, env, [os.path.join(samba3srcdir, "script/tests/test_shadow_copy.sh"), '$SERVER', '$SERVER_IP', '$DOMAIN', '$USERNAME', '$PASSWORD', '$LOCAL_PATH/shadow', smbclient3, '-m', 'SMB3'])
++    plantestsuite("samba3.blackbox.shadow_copy_torture", env, [os.path.join(samba3srcdir, "script/tests/test_shadow_copy_torture.sh"), '$SERVER', '$SERVER_IP', '$DOMAIN', '$USERNAME', '$PASSWORD', '$LOCAL_PATH/shadow', smbtorture4])
+     plantestsuite("samba3.blackbox.smbclient.forceuser_validusers (%s)" % env, env, [os.path.join(samba3srcdir, "script/tests/test_forceuser_validusers.sh"), '$SERVER', '$DOMAIN', '$USERNAME', '$PASSWORD', '$LOCAL_PATH', smbclient3])
+     plantestsuite("samba3.blackbox.smbget (%s)" % env, env, [os.path.join(samba3srcdir, "script/tests/test_smbget.sh"), '$SERVER', '$SERVER_IP', '$DOMAIN', 'smbget_user', '$PASSWORD', '$LOCAL_PATH/smbget', smbget])
+     plantestsuite("samba3.blackbox.netshareenum (%s)" % env, env, [os.path.join(samba3srcdir, "script/tests/test_shareenum.sh"), '$SERVER', '$USERNAME', '$PASSWORD', rpcclient])
+diff --git a/source3/smbd/filename.c b/source3/smbd/filename.c
+index 41c1710..ffc33f3 100644
+--- a/source3/smbd/filename.c
++++ b/source3/smbd/filename.c
+@@ -1555,6 +1555,7 @@ static NTSTATUS build_stream_path(TALLOC_CTX *mem_ctx,
+  *			UCF_ALWAYS_ALLOW_WCARD_LCOMP will be OR'd in if
+  *			p_cont_wcard != NULL and is true and
+  *			UCF_COND_ALLOW_WCARD_LCOMP.
++ * @param twrp		Optional VSS time
+  * @param p_cont_wcard	If not NULL, will be set to true if the dfs path
+  *			resolution detects a wildcard.
+  * @param pp_smb_fname	The final converted name will be allocated if the
+@@ -1568,9 +1569,12 @@ static NTSTATUS filename_convert_internal(TALLOC_CTX *ctx,
+ 				struct smb_request *smbreq,
+ 				const char *name_in,
+ 				uint32_t ucf_flags,
++				time_t *twrp,
+ 				bool *ppath_contains_wcard,
+ 				struct smb_filename **pp_smb_fname)
+ {
++	const char *name = NULL;
++	char *twrp_name = NULL;
+ 	NTSTATUS status;
+ 
+ 	*pp_smb_fname = NULL;
+@@ -1621,14 +1625,37 @@ static NTSTATUS filename_convert_internal(TALLOC_CTX *ctx,
+ 		ucf_flags |= UCF_ALWAYS_ALLOW_WCARD_LCOMP;
+ 	}
+ 
+-	status = unix_convert(ctx, conn, name_in, pp_smb_fname, ucf_flags);
++	name = name_in;
++	if (twrp != NULL) {
++		struct tm *tm = NULL;
++
++		tm = gmtime(twrp);
++		twrp_name = talloc_asprintf(
++			ctx,
++			"@GMT-%04u.%02u.%02u-%02u.%02u.%02u/%s",
++			tm->tm_year + 1900,
++			tm->tm_mon + 1,
++			tm->tm_mday,
++			tm->tm_hour,
++			tm->tm_min,
++			tm->tm_sec,
++			name);
++		if (twrp_name == NULL) {
++			return NT_STATUS_NO_MEMORY;
++		}
++		name = twrp_name;
++	}
++
++	status = unix_convert(ctx, conn, name, pp_smb_fname, ucf_flags);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		DEBUG(10,("filename_convert_internal: unix_convert failed "
+ 			"for name %s with %s\n",
+ 			name_in,
+ 			nt_errstr(status) ));
++		TALLOC_FREE(twrp_name);
+ 		return status;
+ 	}
++	TALLOC_FREE(twrp_name);
+ 
+ 	if ((ucf_flags & UCF_UNIX_NAME_LOOKUP) &&
+ 			VALID_STAT((*pp_smb_fname)->st) &&
+@@ -1663,6 +1690,7 @@ NTSTATUS filename_convert(TALLOC_CTX *ctx,
+ 				connection_struct *conn,
+ 				const char *name_in,
+ 				uint32_t ucf_flags,
++				time_t *twrp,
+ 				bool *ppath_contains_wcard,
+ 				struct smb_filename **pp_smb_fname)
+ {
+@@ -1671,6 +1699,7 @@ NTSTATUS filename_convert(TALLOC_CTX *ctx,
+ 					NULL,
+ 					name_in,
+ 					ucf_flags,
++					twrp,
+ 					ppath_contains_wcard,
+ 					pp_smb_fname);
+ }
+@@ -1693,6 +1722,7 @@ NTSTATUS filename_convert_with_privilege(TALLOC_CTX *ctx,
+ 					smbreq,
+ 					name_in,
+ 					ucf_flags,
++					NULL,
+ 					ppath_contains_wcard,
+ 					pp_smb_fname);
+ }
+diff --git a/source3/smbd/nttrans.c b/source3/smbd/nttrans.c
+index 6847076..e692f52 100644
+--- a/source3/smbd/nttrans.c
++++ b/source3/smbd/nttrans.c
+@@ -543,6 +543,7 @@ void reply_ntcreate_and_X(struct smb_request *req)
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 
+ 	TALLOC_FREE(case_state);
+@@ -1115,6 +1116,7 @@ static void call_nt_transact_create(connection_struct *conn,
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 
+ 	TALLOC_FREE(case_state);
+@@ -1636,6 +1638,7 @@ void reply_ntrename(struct smb_request *req)
+ 				  oldname,
+ 				  ucf_flags_src,
+ 				  NULL,
++				  NULL,
+ 				  &smb_fname_old);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,
+@@ -1652,6 +1655,7 @@ void reply_ntrename(struct smb_request *req)
+ 	status = filename_convert(ctx, conn,
+ 				  newname,
+ 				  ucf_flags_dst,
++				  NULL,
+ 				  &dest_has_wcard,
+ 				  &smb_fname_new);
+ 	if (!NT_STATUS_IS_OK(status)) {
+diff --git a/source3/smbd/open.c b/source3/smbd/open.c
+index 3ae8adb..461fb7e 100644
+--- a/source3/smbd/open.c
++++ b/source3/smbd/open.c
+@@ -5572,6 +5572,7 @@ NTSTATUS get_relative_fid_filename(connection_struct *conn,
+ 				new_base_name,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				smb_fname_out);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		goto out;
+diff --git a/source3/smbd/proto.h b/source3/smbd/proto.h
+index 68fbd8c..4277f20 100644
+--- a/source3/smbd/proto.h
++++ b/source3/smbd/proto.h
+@@ -353,6 +353,7 @@ NTSTATUS filename_convert(TALLOC_CTX *mem_ctx,
+ 			connection_struct *conn,
+ 			const char *name_in,
+ 			uint32_t ucf_flags,
++			time_t *twrp,
+ 			bool *ppath_contains_wcard,
+ 			struct smb_filename **pp_smb_fname);
+ NTSTATUS filename_convert_with_privilege(TALLOC_CTX *mem_ctx,
+diff --git a/source3/smbd/reply.c b/source3/smbd/reply.c
+index 5afe57d..8cdfde4 100644
+--- a/source3/smbd/reply.c
++++ b/source3/smbd/reply.c
+@@ -1306,6 +1306,7 @@ void reply_checkpath(struct smb_request *req)
+ 				name,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 
+ 	if (!NT_STATUS_IS_OK(status)) {
+@@ -1404,6 +1405,7 @@ void reply_getatr(struct smb_request *req)
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 		if (!NT_STATUS_IS_OK(status)) {
+ 			if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -1507,6 +1509,7 @@ void reply_setatr(struct smb_request *req)
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -1804,6 +1807,7 @@ void reply_search(struct smb_request *req)
+ 		nt_status = filename_convert(ctx, conn,
+ 					     path,
+ 					     ucf_flags,
++					     NULL,
+ 					     &mask_contains_wcard,
+ 					     &smb_fname);
+ 		if (!NT_STATUS_IS_OK(nt_status)) {
+@@ -2147,6 +2151,7 @@ void reply_open(struct smb_request *req)
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -2319,6 +2324,7 @@ void reply_open_and_X(struct smb_request *req)
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -2563,6 +2569,7 @@ void reply_mknew(struct smb_request *req)
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -2699,6 +2706,7 @@ void reply_ctemp(struct smb_request *req)
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 		if (!NT_STATUS_IS_OK(status)) {
+ 			if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -3237,6 +3245,7 @@ void reply_unlink(struct smb_request *req)
+ 	status = filename_convert(ctx, conn,
+ 				  name,
+ 				  ucf_flags,
++				  NULL,
+ 				  &path_contains_wcard,
+ 				  &smb_fname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+@@ -6169,6 +6178,7 @@ void reply_mkdir(struct smb_request *req)
+ 				 directory,
+ 				 ucf_flags,
+ 				 NULL,
++				 NULL,
+ 				 &smb_dname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -6239,6 +6249,7 @@ void reply_rmdir(struct smb_request *req)
+ 				 directory,
+ 				 ucf_flags,
+ 				 NULL,
++				 NULL,
+ 				 &smb_dname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -7361,6 +7372,7 @@ void reply_mv(struct smb_request *req)
+ 				  conn,
+ 				  name,
+ 				  src_ucf_flags,
++				  NULL,
+ 				  &src_has_wcard,
+ 				  &smb_fname_src);
+ 
+@@ -7378,6 +7390,7 @@ void reply_mv(struct smb_request *req)
+ 				  conn,
+ 				  newname,
+ 				  dst_ucf_flags,
++				  NULL,
+ 				  &dest_has_wcard,
+ 				  &smb_fname_dst);
+ 
+@@ -7671,6 +7684,7 @@ void reply_copy(struct smb_request *req)
+ 	status = filename_convert(ctx, conn,
+ 				  fname_src,
+ 				  ucf_flags_src,
++				  NULL,
+ 				  &source_has_wild,
+ 				  &smb_fname_src);
+ 	if (!NT_STATUS_IS_OK(status)) {
+@@ -7686,6 +7700,7 @@ void reply_copy(struct smb_request *req)
+ 	status = filename_convert(ctx, conn,
+ 				  fname_dst,
+ 				  ucf_flags_dst,
++				  NULL,
+ 				  &dest_has_wild,
+ 				  &smb_fname_dst);
+ 	if (!NT_STATUS_IS_OK(status)) {
+diff --git a/source3/smbd/smb2_create.c b/source3/smbd/smb2_create.c
+index 7f80f6f..fdd04ac 100644
+--- a/source3/smbd/smb2_create.c
++++ b/source3/smbd/smb2_create.c
+@@ -423,7 +423,7 @@ static NTSTATUS smbd_smb2_create_durable_lease_check(struct smb_request *smb1req
+ 	ucf_flags = filename_create_ucf_flags(smb1req, FILE_OPEN);
+ 	status = filename_convert(talloc_tos(), fsp->conn,
+ 				  filename, ucf_flags,
+-				  NULL, &smb_fname);
++				  NULL, NULL, &smb_fname);
+ 	TALLOC_FREE(filename);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		DEBUG(10, ("filename_convert returned %s\n",
+@@ -476,6 +476,8 @@ struct smbd_smb2_create_state {
+ 	ssize_t lease_len;
+ 	bool need_replay_cache;
+ 	struct smbXsrv_open *op;
++	time_t twrp_time;
++	time_t *twrp_timep;
+ 
+ 	struct smb2_create_blob *dhnc;
+ 	struct smb2_create_blob *dh2c;
+@@ -891,6 +893,7 @@ static struct tevent_req *smbd_smb2_create_send(TALLOC_CTX *mem_ctx,
+ 				  smb1req->conn,
+ 				  state->fname,
+ 				  ucf_flags,
++				  state->twrp_timep,
+ 				  NULL, /* ppath_contains_wcards */
+ 				  &smb_fname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+@@ -1178,9 +1181,6 @@ static void smbd_smb2_create_before_exec(struct tevent_req *req)
+ 
+ 	if (state->twrp != NULL) {
+ 		NTTIME nttime;
+-		time_t t;
+-		struct tm *tm;
+-		char *tmpname = state->fname;
+ 
+ 		if (state->twrp->data.length != 8) {
+ 			tevent_req_nterror(req, NT_STATUS_INVALID_PARAMETER);
+@@ -1188,27 +1188,9 @@ static void smbd_smb2_create_before_exec(struct tevent_req *req)
+ 		}
+ 
+ 		nttime = BVAL(state->twrp->data.data, 0);
+-		t = nt_time_to_unix(nttime);
+-		tm = gmtime(&t);
++		state->twrp_time = nt_time_to_unix(nttime);
++		state->twrp_timep = &state->twrp_time;
+ 
+-		state->fname = talloc_asprintf(
+-			state,
+-			"%s\\@GMT-%04u.%02u.%02u-%02u.%02u.%02u",
+-			state->fname,
+-			tm->tm_year + 1900,
+-			tm->tm_mon + 1,
+-			tm->tm_mday,
+-			tm->tm_hour,
+-			tm->tm_min,
+-			tm->tm_sec);
+-		if (tevent_req_nomem(state->fname, req)) {
+-			return;
+-		}
+-		TALLOC_FREE(tmpname);
+-		/*
+-		 * Tell filename_create_ucf_flags() this
+-		 * is an @GMT path.
+-		 */
+ 		smb1req->flags2 |= FLAGS2_REPARSE_PATH;
+ 	}
+ 
+diff --git a/source3/smbd/smb2_query_directory.c b/source3/smbd/smb2_query_directory.c
+index 50a5bca..fcd4e7a 100644
+--- a/source3/smbd/smb2_query_directory.c
++++ b/source3/smbd/smb2_query_directory.c
+@@ -400,6 +400,7 @@ static struct tevent_req *smbd_smb2_query_directory_send(TALLOC_CTX *mem_ctx,
+ 				conn,
+ 				fullpath,
+ 				ucf_flags,
++				NULL,
+ 				&wcard_has_wild,
+ 				&smb_fname);
+ 
+diff --git a/source3/smbd/trans2.c b/source3/smbd/trans2.c
+index 61757c6..e7a6e05 100644
+--- a/source3/smbd/trans2.c
++++ b/source3/smbd/trans2.c
+@@ -1296,6 +1296,7 @@ static void call_trans2open(connection_struct *conn,
+ 				fname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -2737,6 +2738,7 @@ close_if_end = %d requires_resume_key = %d backup_priv = %d level = 0x%x, max_da
+ 		ntstatus = filename_convert(talloc_tos(), conn,
+ 				    directory,
+ 				    ucf_flags,
++				    NULL,
+ 				    &mask_contains_wcard,
+ 				    &smb_dname);
+ 	}
+@@ -5851,6 +5853,7 @@ static void call_trans2qfilepathinfo(connection_struct *conn,
+ 					fname,
+ 					ucf_flags,
+ 					NULL,
++					NULL,
+ 					&smb_fname);
+ 		if (!NT_STATUS_IS_OK(status)) {
+ 			if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -6687,6 +6690,7 @@ static NTSTATUS smb_set_file_unix_hlink(connection_struct *conn,
+ 				oldname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname_old);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		return status;
+@@ -6762,6 +6766,7 @@ static NTSTATUS smb2_file_rename_information(connection_struct *conn,
+ 				newname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname_dst);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		return status;
+@@ -6872,6 +6877,7 @@ static NTSTATUS smb_file_link_information(connection_struct *conn,
+ 				newname,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_fname_dst);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		return status;
+@@ -8832,6 +8838,7 @@ static void call_trans2setfilepathinfo(connection_struct *conn,
+ 					 fname,
+ 					 ucf_flags,
+ 					 NULL,
++					 NULL,
+ 					 &smb_fname);
+ 		if (!NT_STATUS_IS_OK(status)) {
+ 			if (NT_STATUS_EQUAL(status,NT_STATUS_PATH_NOT_COVERED)) {
+@@ -8981,6 +8988,7 @@ static void call_trans2mkdir(connection_struct *conn, struct smb_request *req,
+ 				directory,
+ 				ucf_flags,
+ 				NULL,
++				NULL,
+ 				&smb_dname);
+ 
+ 	if (!NT_STATUS_IS_OK(status)) {
+diff --git a/source4/torture/smb2/create.c b/source4/torture/smb2/create.c
+index ead56eb..912efaa 100644
+--- a/source4/torture/smb2/create.c
++++ b/source4/torture/smb2/create.c
+@@ -1733,6 +1733,168 @@ done:
+ 	return ret;
+ }
+ 
++static bool test_twrp_write(struct torture_context *tctx, struct smb2_tree *tree)
++{
++	struct smb2_create io;
++	struct smb2_handle h1 = {{0}};
++	NTSTATUS status;
++	bool ret = true;
++	char *p = NULL;
++	struct tm tm;
++	time_t t;
++	uint64_t nttime;
++	const char *file = NULL;
++	const char *snapshot = NULL;
++
++	file = torture_setting_string(tctx, "twrp_file", NULL);
++	if (file == NULL) {
++		torture_skip(tctx, "missing 'twrp_file' option\n");
++	}
++
++	snapshot = torture_setting_string(tctx, "twrp_snapshot", NULL);
++	if (snapshot == NULL) {
++		torture_skip(tctx, "missing 'twrp_snapshot' option\n");
++	}
++
++	torture_comment(tctx, "Testing timewarp (%s) (%s)\n", file, snapshot);
++
++	setenv("TZ", "GMT", 1);
++	p = strptime(snapshot, "@GMT-%Y.%m.%d-%H.%M.%S", &tm);
++	torture_assert_goto(tctx, p != NULL, ret, done, "strptime\n");
++	torture_assert_goto(tctx, *p == '\0', ret, done, "strptime\n");
++
++	t = mktime(&tm);
++	unix_to_nt_time(&nttime, t);
++
++	io = (struct smb2_create) {
++		.in.desired_access = SEC_FILE_READ_DATA,
++		.in.file_attributes = FILE_ATTRIBUTE_NORMAL,
++		.in.create_disposition = NTCREATEX_DISP_OPEN,
++		.in.share_access = NTCREATEX_SHARE_ACCESS_MASK,
++		.in.fname = file,
++		.in.query_maximal_access = true,
++		.in.timewarp = nttime,
++	};
++
++	status = smb2_create(tree, tctx, &io);
++	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
++					"smb2_create\n");
++	smb2_util_close(tree, io.out.file.handle);
++
++	ret = io.out.maximal_access & (SEC_FILE_READ_DATA | SEC_FILE_WRITE_DATA);
++	torture_assert_goto(tctx, ret, ret, done, "Bad access\n");
++
++	io = (struct smb2_create) {
++		.in.desired_access = SEC_FILE_READ_DATA|SEC_FILE_WRITE_DATA,
++		.in.file_attributes = FILE_ATTRIBUTE_NORMAL,
++		.in.create_disposition = NTCREATEX_DISP_OPEN,
++		.in.share_access = NTCREATEX_SHARE_ACCESS_MASK,
++		.in.fname = file,
++		.in.timewarp = nttime,
++	};
++
++	status = smb2_create(tree, tctx, &io);
++	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
++					"smb2_create\n");
++	h1 = io.out.file.handle;
++
++	status = smb2_util_write(tree, h1, "123", 0, 3);
++	torture_assert_ntstatus_equal_goto(tctx, status,
++					   NT_STATUS_MEDIA_WRITE_PROTECTED,
++					   ret, done, "smb2_create\n");
++
++	smb2_util_close(tree, h1);
++
++done:
++	return ret;
++}
++
++static bool test_twrp_stream(struct torture_context *tctx,
++			     struct smb2_tree *tree)
++{
++	struct smb2_create io;
++	NTSTATUS status;
++	bool ret = true;
++	char *p = NULL;
++	struct tm tm;
++	time_t t;
++	uint64_t nttime;
++	const char *file = NULL;
++	const char *stream = NULL;
++	const char *snapshot = NULL;
++	int stream_size;
++	char *path = NULL;
++	uint8_t *buf = NULL;
++	struct smb2_handle h1 = {{0}};
++	struct smb2_read r;
++
++	file = torture_setting_string(tctx, "twrp_file", NULL);
++	if (file == NULL) {
++		torture_skip(tctx, "missing 'twrp_file' option\n");
++	}
++
++	stream = torture_setting_string(tctx, "twrp_stream", NULL);
++	if (stream == NULL) {
++		torture_skip(tctx, "missing 'twrp_stream' option\n");
++	}
++
++	snapshot = torture_setting_string(tctx, "twrp_snapshot", NULL);
++	if (snapshot == NULL) {
++		torture_skip(tctx, "missing 'twrp_snapshot' option\n");
++	}
++
++	stream_size = torture_setting_int(tctx, "twrp_stream_size", 0);
++	if (stream_size == 0) {
++		torture_skip(tctx, "missing 'twrp_stream_size' option\n");
++	}
++
++	torture_comment(tctx, "Testing timewarp on stream (%s) (%s)\n",
++			file, snapshot);
++
++	path = talloc_asprintf(tree, "%s:%s", file, stream);
++	torture_assert_not_null_goto(tctx, path, ret, done, "path\n");
++
++	buf = talloc_zero_array(tree, uint8_t, stream_size);
++	torture_assert_not_null_goto(tctx, buf, ret, done, "buf\n");
++
++	setenv("TZ", "GMT", 1);
++	p = strptime(snapshot, "@GMT-%Y.%m.%d-%H.%M.%S", &tm);
++	torture_assert_goto(tctx, p != NULL, ret, done, "strptime\n");
++	torture_assert_goto(tctx, *p == '\0', ret, done, "strptime\n");
++
++	t = mktime(&tm);
++	unix_to_nt_time(&nttime, t);
++
++	io = (struct smb2_create) {
++		.in.desired_access = SEC_FILE_READ_DATA,
++		.in.file_attributes = FILE_ATTRIBUTE_NORMAL,
++		.in.create_disposition = NTCREATEX_DISP_OPEN,
++		.in.share_access = NTCREATEX_SHARE_ACCESS_MASK,
++		.in.fname = path,
++		.in.timewarp = nttime,
++	};
++
++	status = smb2_create(tree, tctx, &io);
++	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
++					"smb2_create\n");
++	h1 = io.out.file.handle;
++
++	r = (struct smb2_read) {
++		.in.file.handle = h1,
++		.in.length = stream_size,
++		.in.offset = 0,
++	};
++
++	status = smb2_read(tree, tree, &r);
++	torture_assert_ntstatus_ok_goto(tctx, status, ret, done,
++					"smb2_create\n");
++
++	smb2_util_close(tree, h1);
++
++done:
++	return ret;
++}
++
+ /*
+    basic testing of SMB2 read
+ */
+@@ -1758,3 +1920,15 @@ struct torture_suite *torture_smb2_create_init(TALLOC_CTX *ctx)
+ 
+ 	return suite;
+ }
++
++struct torture_suite *torture_smb2_twrp_init(TALLOC_CTX *ctx)
++{
++	struct torture_suite *suite = torture_suite_create(ctx, "twrp");
++
++	torture_suite_add_1smb2_test(suite, "write", test_twrp_write);
++	torture_suite_add_1smb2_test(suite, "stream", test_twrp_stream);
++
++	suite->description = talloc_strdup(suite, "SMB2-TWRP tests");
++
++	return suite;
++}
+diff --git a/source4/torture/smb2/smb2.c b/source4/torture/smb2/smb2.c
+index 6f9884e..a835dc7 100644
+--- a/source4/torture/smb2/smb2.c
++++ b/source4/torture/smb2/smb2.c
+@@ -154,6 +154,7 @@ NTSTATUS torture_smb2_init(TALLOC_CTX *ctx)
+ 	torture_suite_add_suite(suite, torture_smb2_read_init(suite));
+ 	torture_suite_add_suite(suite, torture_smb2_aio_delay_init(suite));
+ 	torture_suite_add_suite(suite, torture_smb2_create_init(suite));
++	torture_suite_add_suite(suite, torture_smb2_twrp_init(suite));
+ 	torture_suite_add_suite(suite, torture_smb2_acls_init(suite));
+ 	torture_suite_add_suite(suite, torture_smb2_notify_init(suite));
+ 	torture_suite_add_suite(suite, torture_smb2_notify_inotify_init(suite));
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Fixes an incompatibility between streams and internal snapshot path handling in Samba that prevents restoration of previous versions of files that contain an alternate data stream.