### PR TITLE
tkt-63402: Switch collectd ctl plugin to new CTL statistics API.

### DIFF
--- a/net-mgmt/collectd5/Makefile
+++ b/net-mgmt/collectd5/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	collectd
 PORTVERSION=	5.7.2
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	net-mgmt
 MASTER_SITES=	https://storage.googleapis.com/collectd-tarballs/
 PKGNAMESUFFIX=	5


### PR DESCRIPTION
Previous API consumed too much memory, but also appeared to be broken
after FreeBSD 11.2 merge.

Ticket:	#63402
(cherry picked from commit 51eca18e09220459a27f9eddaf3297dd19d8f52c)