### PR TITLE
tkt-64716: Suppress RAM Usage warnings

### DIFF
--- a/net-mgmt/netdata/files/patch-health_health.d_ram.conf
+++ b/net-mgmt/netdata/files/patch-health_health.d_ram.conf
@@ -1,0 +1,18 @@
+--- health/health.d/ram.conf.orig	2019-01-02 18:33:16 UTC
++++ health/health.d/ram.conf
+@@ -48,7 +48,7 @@ every: 10s
+  crit: $this > (($status == $CRITICAL) ? (90) : (98))
+ delay: down 15m multiplier 1.5 max 1h
+  info: system RAM usage
+-   to: sysadmin
++   to: silent
+ 
+  alarm: ram_available
+     on: system.ram
+@@ -61,4 +61,4 @@ delay: down 15m multiplier 1.5 max 1h
+   crit: $this < (($status == $CRITICAL) ? (10) : ( 5))
+  delay: down 15m multiplier 1.5 max 1h
+   info: estimated amount of RAM available for userspace processes, without causing swapping
+-    to: sysadmin
++    to: silent
+


### PR DESCRIPTION
This commit suppresses netdata complains about RAM usage by default.
Ticket: #64716