### PR TITLE
tkt-72011: Automatically enable zfsacl if sysvol supports nfs4 acls. (by anodos325)

### DIFF
--- a/net/samba49/files/0001-zfs-provisioning-patches.patch
+++ b/net/samba49/files/0001-zfs-provisioning-patches.patch
@@ -189,6 +189,24 @@ index c80f8f3..51077bc 100644
  #undef  DBGC_CLASS
  #define DBGC_CLASS DBGC_ACLS
  
+diff --git a/source3/param/loadparm.c b/source3/param/loadparm.c
+index 322934c..3e3e134 100644
+--- a/source3/param/loadparm.c
++++ b/source3/param/loadparm.c
+@@ -2744,6 +2744,13 @@ static void init_locals(void)
+ 				lp_do_parameter(-1, "vfs objects", "dfs_samba4 acl_xattr xattr_tdb");
+ 			} else if (lp_parm_const_string(-1, "posix", "eadb", NULL)) {
+ 				lp_do_parameter(-1, "vfs objects", "dfs_samba4 acl_xattr posix_eadb");
++	/*
++ 	 * By default, the samba sysvol is located in the statedir. Provisioning will fail in setntacl
++ 	 * unless we have zfacl enabled. Unfortunately, at this point the smb.conf has not been generated.
++ 	 * This workaround is freebsd-specific.
++ 	 */
++			} else if (pathconf(get_dyn_STATEDIR(), _PC_ACL_NFS4) == 1){
++				lp_do_parameter(-1, "vfs objects", "dfs_samba4 zfsacl");
+ 			} else {
+ 				lp_do_parameter(-1, "vfs objects", "dfs_samba4 acl_xattr");
+ 			}
 diff --git a/source3/smbd/pysmbd.c b/source3/smbd/pysmbd.c
 index 1431925..5d565e7 100644
 --- a/source3/smbd/pysmbd.c


### PR DESCRIPTION
sysvol acl reset during domain provisioning can fail due to
fset_nt_acl failing with NT_STATUS_INVALID_PARAMETER. This is
because samba defaults to setting the acl_xattr vfs object for
domain controllers unless it is explicitly overriden. During
provisioning there is not a reliable mechanism to ensure that
we are overriding the default with zfsacl. Instead, check for
nfs4 ACL support on samba's statedir (the default location for
the sysvol share), and enable zfsacl accordingly.