### PR TITLE
tkt-74190: Add support for WS-Discovery to samba port (by anodos325)

### DIFF
--- a/net/samba49/Makefile
+++ b/net/samba49/Makefile
@@ -89,7 +89,7 @@ SUB_LIST+=			PKGCONFIGDIR=${PKGCONFIGDIR_REL}
 # Options
 OPTIONS_SUB=			yes
 
-OPTIONS_DEFINE=			AD_DC ADS DEBUG DOCS FAM LDAP LIBZFS\
+OPTIONS_DEFINE=			AD_DC ADS DEBUG DOCS FAM LDAP LIBZFS WSDD\
 				QUOTAS SYSLOG UTMP
 # Make those default options
 OPTIONS_DEFAULT:=		${OPTIONS_DEFINE}
@@ -115,6 +115,7 @@ GPGME_DESC=			GpgME
 GLUSTERFS_DESC=			GlusterFS
 LDAP_DESC=			LDAP client
 LIBZFS_DESC=			LibZFS
+WSDD_DESC=			Web Service Discovery Daemon
 SPOTLIGHT_DESC=			Spotlight
 MANDOC_DESC=			Build manpages from DOCBOOK templates
 NTVFS_DESC=			Build *DEPRECATED* NTVFS file server
@@ -311,6 +312,8 @@ GLUSTERFS_VARS=			SAMBA4_MODULES+=vfs_glusterfs
 
 GPGME_CONFIGURE_WITH=		gpgme
 GPGME_LIB_DEPENDS=		libgpgme.so:security/gpgme
+
+WSDD_RUN_DEPENDS=		py${PYTHON3_DEFAULT:S/.//}-wsdd>=1.0.0:sysutils/py-wsdd
 
 PROFILE_CONFIGURE_WITH=		profiling-data
 

--- a/net/samba49/Makefile
+++ b/net/samba49/Makefile
@@ -49,6 +49,7 @@ SAMBA4_MODULEDIR=		${PREFIX}/lib/shared-modules
 SAMBA4_INCLUDEDIR=		${PREFIX}/include/${SAMBA4_PORTNAME}
 SAMBA4_CONFDIR=			${PREFIX}/etc
 SAMBA4_CONFIG=			smb4.conf
+SAMBA4_PYTHON3_CMD=		${LOCALBASE}/bin/python${PYTHON3_DEFAULT}
 
 CONFIGURE_ARGS+=		--mandir="${MANPREFIX}/man" \
 				--sysconfdir="${SAMBA4_CONFDIR}" \
@@ -544,6 +545,9 @@ pre-build-MANDOC-off:
 					${INSTALL_MAN} ${FILESDIR}/man/${man} ${BUILD_WRKSRC}/bin/default/ctdb/
 .	endfor
 .endif
+
+pre-install:
+				@${REINPLACE_CMD} -e 's|%%PYTHON_CMD%%|${SAMBA4_PYTHON3_CMD}|g' ${WRKDIR}/samba_server 
 
 post-install-rm-junk:
 .for f in vfs_aio_linux.8 vfs_btrfs.8 vfs_ceph.8 vfs_gpfs.8

--- a/net/samba49/Makefile
+++ b/net/samba49/Makefile
@@ -547,7 +547,7 @@ pre-build-MANDOC-off:
 .endif
 
 pre-install:
-				@${REINPLACE_CMD} -e 's|%%PYTHON_CMD%%|${SAMBA4_PYTHON3_CMD}|g' ${WRKDIR}/samba_server 
+				@${REINPLACE_CMD} -e 's|%%SAMBA4_PYTHON3_CMD%%|${SAMBA4_PYTHON3_CMD}|g' ${WRKDIR}/samba_server 
 
 post-install-rm-junk:
 .for f in vfs_aio_linux.8 vfs_btrfs.8 vfs_ceph.8 vfs_gpfs.8

--- a/net/samba49/files/0001-add-parameters-for-ha-configuration.patch
+++ b/net/samba49/files/0001-add-parameters-for-ha-configuration.patch
@@ -1,3 +1,20 @@
+diff --git a/docs-xml/smbdotconf/base/enablewebservicediscovery.xml b/docs-xml/smbdotconf/base/enablewebservicediscovery.xml
+new file mode 100644
+index 0000000..9495393
+--- /dev/null
++++ b/docs-xml/smbdotconf/base/enablewebservicediscovery.xml
+@@ -0,0 +1,11 @@
++<samba:parameter name="enable web service discovery"
++                 type="boolean"
++                 context="G"
++                 xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
++<description>
++        <para>Enable Web Services Dynamic Discovery (WS-Discovery) to
++        make samba_server appear in Network Neighborhood on Windows
++        clients.</para>
++</description>
++<value type="default">no</value>
++</samba:parameter>
 diff --git a/docs-xml/smbdotconf/base/truenaspassivecontroller.xml b/docs-xml/smbdotconf/base/truenaspassivecontroller.xml
 new file mode 100644
 index 0000000..ad7499b
@@ -86,10 +103,18 @@ index a9405e8..95c1c8a 100644
  			/*
  			 * Add HOST/NETBIOSNAME
 diff --git a/source3/param/loadparm.c b/source3/param/loadparm.c
-index 322934c..eefae67 100644
+index 322934c..91a55de 100644
 --- a/source3/param/loadparm.c
 +++ b/source3/param/loadparm.c
-@@ -723,6 +723,10 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
+@@ -688,6 +688,7 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
+ #endif
+ 	Globals.time_server = false;
+ 	Globals.bind_interfaces_only = false;
++	Globals.enable_web_service_discovery = false;
+ 	Globals.unix_password_sync = false;
+ 	Globals.pam_password_change = false;
+ 	Globals.passwd_chat_debug = false;
+@@ -723,6 +724,10 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
  	Globals.log_writeable_files_on_exit = false;
  	Globals.create_krb5_conf = true;
  	Globals.include_system_krb5_conf = true;

--- a/net/samba49/files/samba_server.in
+++ b/net/samba49/files/samba_server.in
@@ -20,7 +20,7 @@
 # You need to enable winbindd separately, by adding:
 #winbindd_enable="YES"
 # Configuration file can be set with:
-#samba_server_config="%%SAMBA4_CONFDIR%%/%%SAMBA4_CONFIG%%"
+#samba_server_config="/usr/local/etc/smb4.conf"
 #
 
 . /etc/rc.subr
@@ -43,6 +43,9 @@ configtest_cmd="samba_server_checkconfig"
 reload_cmd="samba_server_reload_cmd"
 rcvar_cmd="samba_server_rcvar_cmd"
 
+wsdd_cmd="%%PREFIX%%/bin/wsdd.py"
+python3_cmd="/usr/local/bin/python3"
+
 samba_server_checkconfig() {
     echo -n "Performing sanity check on Samba configuration: "
     if ${testparm_command} >/dev/null 2>&1; then
@@ -62,7 +65,58 @@ samba_server_prestart() {
     if [ -d "${samba_server_privatedir}" -o ! -e "${samba_server_privatedir}" ]; then
 	install -d -m 0700 "${samba_server_privatedir}"
     fi
+    # Winbind will fail to start if permissions on winbindd_privileged is wrong.
+    # Fix permissions if needed.
+    if [ -d "${samba_server_statedir}"/winbindd_privileged ] && \
+       [ $(stat -f %p "${samba_server_statedir}"/winbindd_privileged) != 40750 ]; then
+        chmod 0750 "${samba_server_statedir}"/winbindd_privileged
+    fi
     samba_server_checkconfig
+}
+
+samba_server_wsdd_cmd() {
+    local workgroup interfaces pidfile wsdd_opts wsdd_pid
+    pidfile="${samba_server_piddir}/wsdd.pid"
+    workgroup="$(${testparm_command} --parameter-name='workgroup' 2>/dev/null)"
+    interfaces="$(${testparm_command} --parameter-name='interfaces' 2>/dev/null)"
+    wsdd_opts="-w ${workgroup}"
+    if [ ${interfaces} ]; then
+	wsdd_opts="${wsdd_opts} -i ${interfaces}"
+    fi
+    bind_interfaces="$(${testparm_command} --parameter-name='interfaces' 2>/dev/null)"
+    case ${rc_arg} in
+	start)
+	    if [ ! -f ${pidfile} ]; then
+	        /usr/sbin/daemon -p ${pidfile} -S ${python3_cmd} ${wsdd_cmd} ${wsdd_opts} 
+		debug "Starting wsdd"
+	        echo "Starting wsdd"
+            else
+	        wsdd_pid=$(cat "${pidfile}")
+	        debug "wsdd already running?  (pid=${wsdd_pid})"
+	        echo "wsdd already running?  (pid=${wsdd_pid})"
+	    fi
+	;;
+	stop)
+	    if [ -f ${pidfile} ]; then
+	        wsdd_pid=$(cat "${pidfile}")
+		debug "Stopping wsdd: ${wsdd_pid}"
+	        echo "Stopping wsdd: ${wsdd_pid}"
+	        kill -9 ${wsdd_pid}
+	    fi
+	;;
+	status)
+	    if [ -f ${pidfile} ]; then
+	        wsdd_pid=$(cat "${pidfile}")
+	        debug "wsdd running is running as pid ${wsdd_pid}."
+	        echo "wsdd running is running as pid ${wsdd_pid}."
+	    else
+	        debug "wsdd: stopped"
+	        echo "wsdd: stopped"
+	    fi
+	;;
+	auto|*)
+	;;
+    esac
 }
 
 samba_server_rcvar_cmd() {
@@ -133,6 +187,9 @@ samba_server_cmd() {
 	    result=$((${result} || $?))
 	fi
     done
+    if [ ${wsdd_enabled} == 'Yes' ]; then
+	samba_server_wsdd_cmd
+    fi
     return ${result}
 }
 
@@ -148,6 +205,8 @@ samba_server_config_init() {
     testparm_command="%%PREFIX%%/bin/testparm --suppress-prompt --verbose ${samba_server_config}"
     # Determine what daemons are necessary to run Samba in the current role
     samba_server_role=$(${testparm_command} --parameter-name='server role' 2>/dev/null)
+    nmbd_disabled=$(${testparm_command} --parameter-name='disable netbios' 2>/dev/null)
+    wsdd_enabled=$(${testparm_command} --parameter-name='enable web service discovery' 2>/dev/null) 
     case "${samba_server_role}" in
 	active\ directory\ domain\ controller)
 	    samba_daemons="samba"
@@ -156,21 +215,22 @@ samba_server_config_init() {
 	    samba_daemons="nmbd smbd winbindd"
 	    ;;
     esac
+
     # Load daemons configuration
     for name in ${samba_daemons}; do
 	load_rc_config "${name}"
 	# If samba_server_enable is 'YES'
 	if [ -n "${rcvar}" ] && checkyesno "${rcvar}"; then
-	    if [ "${name}" != "winbindd" ]; then
-		# Set variable to 'YES' only if it is unset
-		eval ${name}_enable=\${${name}_enable-YES}
-	    else
-		# Winbindd
-		samba_server_idmap=$(${testparm_command} --parameter-name='idmap uid' 2>/dev/null)
-		if [ -n "${samba_server_idmap}" ]; then
-		    winbindd_enable="YES"
-		fi
-	    fi
+	    case "${name}" in
+	        nmbd)
+	            if [ ${nmbd_disabled} == "No" ]; then
+		        eval ${name}_enable=\${${name}_enable-YES}
+                    fi
+	            ;;
+	        auto|*)
+		    eval ${name}_enable=\${${name}_enable-YES}
+	    esac
+
 	fi
 	# If variable is empty, set it to 'NO'
 	eval ${name}_enable=\${${name}_enable:-NO}
@@ -182,6 +242,7 @@ samba_server_config_init() {
     samba_server_piddir=${samba_server_piddir:=%%SAMBA4_RUNDIR%%}
     samba_server_privatedir="$(${testparm_command} --parameter-name='private dir' 2>/dev/null)"
     samba_server_privatedir=${samba_server_privatedir:=%%SAMBA4_PRIVATEDIR%%}
+    samba_server_statedir="$(${testparm_command} --parameter-name='state directory' 2>/dev/null)"
 }
 
 # Load configuration variables

--- a/net/samba49/files/samba_server.in
+++ b/net/samba49/files/samba_server.in
@@ -20,7 +20,7 @@
 # You need to enable winbindd separately, by adding:
 #winbindd_enable="YES"
 # Configuration file can be set with:
-#samba_server_config="/usr/local/etc/smb4.conf"
+#samba_server_config="%%SAMBA4_CONFDIR%%/%%SAMBA4_CONFIG%%"
 #
 
 . /etc/rc.subr
@@ -44,7 +44,7 @@ reload_cmd="samba_server_reload_cmd"
 rcvar_cmd="samba_server_rcvar_cmd"
 
 wsdd_cmd="%%PREFIX%%/bin/wsdd.py"
-python3_cmd="/usr/local/bin/python3"
+python3_cmd="%%PYTHON_CMD%%"
 
 samba_server_checkconfig() {
     echo -n "Performing sanity check on Samba configuration: "
@@ -79,11 +79,11 @@ samba_server_wsdd_cmd() {
     pidfile="${samba_server_piddir}/wsdd.pid"
     workgroup="$(${testparm_command} --parameter-name='workgroup' 2>/dev/null)"
     interfaces="$(${testparm_command} --parameter-name='interfaces' 2>/dev/null)"
-    wsdd_opts="-w ${workgroup}"
-    if [ ${interfaces} ]; then
-	wsdd_opts="${wsdd_opts} -i ${interfaces}"
+    if [ ! -z "${interfaces}" ]; then
+	wsdd_opts="-w ${workgroup} -i ${interfaces}"
+    else
+	wsdd_opts="-w ${workgroup}"
     fi
-    bind_interfaces="$(${testparm_command} --parameter-name='interfaces' 2>/dev/null)"
     case ${rc_arg} in
 	start)
 	    if [ ! -f ${pidfile} ]; then
@@ -114,7 +114,7 @@ samba_server_wsdd_cmd() {
 	        echo "wsdd: stopped"
 	    fi
 	;;
-	auto|*)
+	*)
 	;;
     esac
 }
@@ -211,7 +211,7 @@ samba_server_config_init() {
 	active\ directory\ domain\ controller)
 	    samba_daemons="samba"
 	    ;;
-	auto|*)
+	*)
 	    samba_daemons="nmbd smbd winbindd"
 	    ;;
     esac
@@ -227,7 +227,7 @@ samba_server_config_init() {
 		        eval ${name}_enable=\${${name}_enable-YES}
                     fi
 	            ;;
-	        auto|*)
+	        *)
 		    eval ${name}_enable=\${${name}_enable-YES}
 	    esac
 

--- a/net/samba49/files/samba_server.in
+++ b/net/samba49/files/samba_server.in
@@ -44,7 +44,7 @@ reload_cmd="samba_server_reload_cmd"
 rcvar_cmd="samba_server_rcvar_cmd"
 
 wsdd_cmd="%%PREFIX%%/bin/wsdd.py"
-python3_cmd="%%PYTHON_CMD%%"
+python3_cmd="%%SAMBA4_PYTHON3_CMD%%"
 
 samba_server_checkconfig() {
     echo -n "Performing sanity check on Samba configuration: "
@@ -87,10 +87,10 @@ samba_server_wsdd_cmd() {
     case ${rc_arg} in
 	start)
 	    if [ ! -f ${pidfile} ]; then
-	        /usr/sbin/daemon -p ${pidfile} -S ${python3_cmd} ${wsdd_cmd} ${wsdd_opts} 
+	        /usr/sbin/daemon -p ${pidfile} -S ${python3_cmd} ${wsdd_cmd} ${wsdd_opts}
 		debug "Starting wsdd"
 	        echo "Starting wsdd"
-            else
+	    else
 	        wsdd_pid=$(cat "${pidfile}")
 	        debug "wsdd already running?  (pid=${wsdd_pid})"
 	        echo "wsdd already running?  (pid=${wsdd_pid})"
@@ -99,7 +99,7 @@ samba_server_wsdd_cmd() {
 	stop)
 	    if [ -f ${pidfile} ]; then
 	        wsdd_pid=$(cat "${pidfile}")
-		debug "Stopping wsdd: ${wsdd_pid}"
+	        debug "Stopping wsdd: ${wsdd_pid}"
 	        echo "Stopping wsdd: ${wsdd_pid}"
 	        kill -9 ${wsdd_pid}
 	    fi

--- a/sysutils/py-wsdd/Makefile
+++ b/sysutils/py-wsdd/Makefile
@@ -1,0 +1,23 @@
+# $FreeBSD$
+
+PORTNAME=	wsdd	
+PORTVERSION=	1.0		
+PORTREVISION=	0	
+CATEGORIES=	sysutils python
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	awalker@ixsystems.com
+COMMENT=	Python WS-Discovery implementation	
+
+USES=		python:3.6+
+USE_PYTHON=	distutils
+USE_GITHUB=	yes
+GH_ACCOUNT=	freenas	
+GH_PROJECT=	wsdd
+GH_TAGNAME=	0195eff4972dd5ef65c050e312f5677cda0617ec	
+
+post-install:
+		${LN} -sf ${PYTHON_SITELIBDIR}/wsdd/wsdd.py ${LOCALBASE}/bin/wsdd.py
+		chmod +x ${LOCALBASE}/bin/wsdd.py	
+
+.include <bsd.port.mk>

--- a/sysutils/py-wsdd/distinfo
+++ b/sysutils/py-wsdd/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1545294480 
+SHA256 (freenas-wsdd-1.0-0195eff4972dd5ef65c050e312f5677cda0617ec_GH0.tar.gz) = 9ffa7a0b10f1cda1810aa1d25543d9e7be3e594184806ff7fb5d5c83dc765d94 
+SIZE (freenas-wsdd-1.0-0195eff4972dd5ef65c050e312f5677cda0617ec_GH0.tar.gz) = 21205

--- a/sysutils/py-wsdd/pkg-descr
+++ b/sysutils/py-wsdd/pkg-descr
@@ -1,0 +1,3 @@
+wsdd implements a Web Service Discovery host daemon. This enables (Samba) hosts, like your local NAS device, to be found by Web Service Discovery Clients like Windows.
+
+WWW: https://github.com/freenas/wsdd


### PR DESCRIPTION
- Currently defaults to off
- Can be enabled by setting "enable web service discovery = Yes" as a global smb4.conf parameter if py-wsdd port is installed.

- Also add ability to disable the netbios name server (nmbd), and permissions check / fix for "/var/db/samba4/winbindd_privileged" during samba_server commands (There are an increasing number of occurrences of freenas users breaking these permissions; thus additional safety net is needed).