### PR TITLE
tkt-76269: Fix issue with creating BUILTIN accounts in ldapsam

### DIFF
--- a/net/samba49/Makefile
+++ b/net/samba49/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}49
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			2
+PORTREVISION=			3
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -24,6 +24,7 @@ EXTRA_PATCHES+=		 	${PATCHDIR}/0001-add-support-for-xattrs-larger-than-64k.patch
 EXTRA_PATCHES+=		 	${PATCHDIR}/0001-add-parameters-for-ha-configuration.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/0001-add-idmap_fruit-backend.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/0001-fix-listen-backlog.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/0001-fix-ldapsam.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba49/files/0001-fix-ldapsam.patch
+++ b/net/samba49/files/0001-fix-ldapsam.patch
@@ -1,0 +1,39 @@
+diff --git a/source3/passdb/pdb_ldap.c b/source3/passdb/pdb_ldap.c
+index 1ac6c50..5d58316 100644
+--- a/source3/passdb/pdb_ldap.c
++++ b/source3/passdb/pdb_ldap.c
+@@ -68,6 +68,9 @@
+ #include "passdb/pdb_ldap_util.h"
+ #include "passdb/pdb_ldap_schema.h"
+ 
++
++static bool ldap_map_builtin;
++
+ /**********************************************************************
+  Simple helper function to make stuff better readable
+  **********************************************************************/
+@@ -6487,6 +6490,12 @@ static void free_private_data(void **vp)
+ 	/* No need to free any further, as it is talloc()ed */
+ }
+ 
++static bool ldapsam_is_responsible_for_builtin(struct pdb_methods *m)
++{
++	return ldap_map_builtin;
++}
++
++
+ /*********************************************************************
+  Intitalise the parts of the pdb_methods structure that are common to 
+  all pdb_ldap modes
+@@ -6520,6 +6529,11 @@ static NTSTATUS pdb_init_ldapsam_common(struct pdb_methods **pdb_method, const c
+ 	(*pdb_method)->delete_group_mapping_entry = ldapsam_delete_group_mapping_entry;
+ 	(*pdb_method)->enum_group_mapping = ldapsam_enum_group_mapping;
+ 
++	(*pdb_method)->is_responsible_for_builtin =
++						ldapsam_is_responsible_for_builtin;
++	ldap_map_builtin = lp_parm_bool(-1, "ldapsam", "map builtin", true);
++
++
+ 	(*pdb_method)->get_account_policy = ldapsam_get_account_policy;
+ 	(*pdb_method)->set_account_policy = ldapsam_set_account_policy;
+ 


### PR DESCRIPTION
Changes in samba 4.9 caused the ldapsam backend to attempt to create BUILTIN accounts on the remote LDAP server. Introduce parameter "ldapsam:map builtin" for the ldapsam pdb backend. When set to False, this parameter will pass along mapping of BUILTIN accounts to winbind.