### PR TITLE
Fix guest account intialization in readonly LDAP environments

### DIFF
--- a/net/samba49/Makefile
+++ b/net/samba49/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}49
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			2
+PORTREVISION=			3
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -24,6 +24,7 @@ EXTRA_PATCHES+=		 	${PATCHDIR}/0001-add-support-for-xattrs-larger-than-64k.patch
 EXTRA_PATCHES+=		 	${PATCHDIR}/0001-add-parameters-for-ha-configuration.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/0001-add-idmap_fruit-backend.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/0001-fix-listen-backlog.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/0001-fix-builtin-guests-ldap.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba49/files/0001-fix-builtin-guests-ldap.patch
+++ b/net/samba49/files/0001-fix-builtin-guests-ldap.patch
@@ -1,0 +1,14 @@
+diff --git a/source3/auth/token_util.c b/source3/auth/token_util.c
+index f5b0e69..d2bc9f7 100644
+--- a/source3/auth/token_util.c
++++ b/source3/auth/token_util.c
+@@ -745,7 +745,8 @@ NTSTATUS finalize_local_nt_token(struct security_token *result,
+ 		status = create_builtin_guests(domain_sid);
+ 		unbecome_root();
+ 
+-		if (NT_STATUS_EQUAL(status, NT_STATUS_PROTOCOL_UNREACHABLE)) {
++		if (NT_STATUS_EQUAL(status, NT_STATUS_PROTOCOL_UNREACHABLE) || 
++                    NT_STATUS_EQUAL(status, NT_STATUS_ACCESS_DENIED)) {
+ 			/*
+ 			 * Add BUILTIN\Guests directly to token.
+ 			 * But only if the token already indicates


### PR DESCRIPTION
If create_builtin_guests() fails with NT_STATUS_ACCESS_DENIED (i.e. no write access to the remote LDAP server), then add BUILTIN\guests directly to token. 