### PR TITLE
[converters/convmv] Sync port to upstream version (2.05)

### DIFF
--- a/converters/convmv/Makefile
+++ b/converters/convmv/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	convmv
-PORTVERSION=	2.03
+PORTVERSION=	2.05
 CATEGORIES=	converters perl5
 MASTER_SITES=	http://www.j3e.de/linux/convmv/ \
 		http://www.sfr-fresh.com/unix/privat/

--- a/converters/convmv/distinfo
+++ b/converters/convmv/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1499271158
-SHA256 (convmv-2.03.tar.gz) = f898fd850c8ef5abe48f7536e4b23ce4e11b6133974b2fc41d9197dfecc1c027
-SIZE (convmv-2.03.tar.gz) = 29688
+TIMESTAMP = 1551008286
+SHA256 (convmv-2.05.tar.gz) = 53b6ac8ae4f9beaee5bc5628f6a5382bfd14f42a5bed3d881b829d7b52d81ca6
+SIZE (convmv-2.05.tar.gz) = 30680


### PR DESCRIPTION
(cherry-picked 5f17486ff9e185c77519be330b815243a8ee236d)

Ticket: https://redmine.ixsystems.com/issues/78141