### PR TITLE
NAS-101427: Improve sedutil FreeBSD support / 11.2

### DIFF
--- a/sysutils/sedutil/Makefile
+++ b/sysutils/sedutil/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	sedutil
 PORTVERSION=	1.15.1
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	sysutils
 
 MAINTAINER=	mav@FreeBSD.org
@@ -14,7 +14,7 @@ LICENSE=	GPLv3
 USES=		gmake
 USE_GITHUB=	yes
 GH_ACCOUNT=	amotin
-GH_TAGNAME=	e8a35ab0
+GH_TAGNAME=	fcc545ea
 
 PLIST_FILES=	sbin/sedutil-cli man/man8/sedutil-cli.8.gz
 

--- a/sysutils/sedutil/Makefile
+++ b/sysutils/sedutil/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	sedutil
 PORTVERSION=	1.15.1
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	sysutils
 
 MAINTAINER=	mav@FreeBSD.org
@@ -14,14 +14,15 @@ LICENSE=	GPLv3
 USES=		gmake
 USE_GITHUB=	yes
 GH_ACCOUNT=	amotin
-GH_TAGNAME=	54cf58a9
+GH_TAGNAME=	e8a35ab0
 
-PLIST_FILES=	sbin/sedutil-cli
+PLIST_FILES=	sbin/sedutil-cli man/man8/sedutil-cli.8.gz
 
 do-build:
 	(cd ${WRKSRC}/freebsd/CLI/ && gmake)
 
 do-install:
 	${INSTALL_PROGRAM} ${WRKSRC}/freebsd/CLI/dist/Release/CLang-Generic/sedutil-cli ${STAGEDIR}${PREFIX}/sbin
+	${INSTALL_MAN} ${WRKSRC}/docs/sedutil-cli.8 ${STAGEDIR}${MANPREFIX}/man/man8
 
 .include <bsd.port.mk>

--- a/sysutils/sedutil/Makefile
+++ b/sysutils/sedutil/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	sedutil
 PORTVERSION=	1.15.1
+PORTREVISION=	1
 CATEGORIES=	sysutils
 
 MAINTAINER=	mav@FreeBSD.org
@@ -13,7 +14,7 @@ LICENSE=	GPLv3
 USES=		gmake
 USE_GITHUB=	yes
 GH_ACCOUNT=	amotin
-GH_TAGNAME=	a7c416ee
+GH_TAGNAME=	54cf58a9
 
 PLIST_FILES=	sbin/sedutil-cli
 

--- a/sysutils/sedutil/distinfo
+++ b/sysutils/sedutil/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1555081447
-SHA256 (amotin-sedutil-1.15.1-e8a35ab0_GH0.tar.gz) = e0ee470c25973e3865727df096c3569c81e42709924bca404c3cd3f716c50fcb
-SIZE (amotin-sedutil-1.15.1-e8a35ab0_GH0.tar.gz) = 311815
+TIMESTAMP = 1555268523
+SHA256 (amotin-sedutil-1.15.1-fcc545ea_GH0.tar.gz) = 8f0757df9594b33f3eca49b68cd08b39efce10bfef237f19e0e719dfcaa0f0b7
+SIZE (amotin-sedutil-1.15.1-fcc545ea_GH0.tar.gz) = 311836

--- a/sysutils/sedutil/distinfo
+++ b/sysutils/sedutil/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1538751504
-SHA256 (amotin-sedutil-1.15.1-54cf58a9_GH0.tar.gz) = 10e9893e9f87f0b44bc83abf0ddad5fe412808b6aaf8ebaa1d4da966a1b3b837
-SIZE (amotin-sedutil-1.15.1-54cf58a9_GH0.tar.gz) = 308392
+TIMESTAMP = 1555081447
+SHA256 (amotin-sedutil-1.15.1-e8a35ab0_GH0.tar.gz) = e0ee470c25973e3865727df096c3569c81e42709924bca404c3cd3f716c50fcb
+SIZE (amotin-sedutil-1.15.1-e8a35ab0_GH0.tar.gz) = 311815

--- a/sysutils/sedutil/distinfo
+++ b/sysutils/sedutil/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1523154516
-SHA256 (amotin-sedutil-1.15.1-a7c416ee_GH0.tar.gz) = 9a1d0ec4e66a82da780e760db1a2b51c68325e171cec64edb7422a018449047d
-SIZE (amotin-sedutil-1.15.1-a7c416ee_GH0.tar.gz) = 308372
+TIMESTAMP = 1538751504
+SHA256 (amotin-sedutil-1.15.1-54cf58a9_GH0.tar.gz) = 10e9893e9f87f0b44bc83abf0ddad5fe412808b6aaf8ebaa1d4da966a1b3b837
+SIZE (amotin-sedutil-1.15.1-54cf58a9_GH0.tar.gz) = 308392


### PR DESCRIPTION
While being there I've also added initial support for Opalite and Pyrite SSC specifications, found in some devices.