### PR TITLE
NAS-101788 / 11.2 / Don't send empty alerts

### DIFF
--- a/sysutils/tw_cli/Makefile
+++ b/sysutils/tw_cli/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	tw_cli
 PORTVERSION=	9.5.5
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	sysutils
 MASTER_SITES=	https://docs.broadcom.com/docs-and-downloads/raid-controllers/raid-controllers-common-files/
 DISTNAME=	CLI_freebsd-from_the_10-2-2-1_9-5-5-1_codesets

--- a/sysutils/tw_cli/files/407.status-3ware-raid.in
+++ b/sysutils/tw_cli/files/407.status-3ware-raid.in
@@ -61,9 +61,17 @@ case "$daily_status_3ware_raid_enable" in
 		fi
 		mv -f ${alarms_log}.today ${alarms_log}.yesterday
 		${tw_cli} alarms > ${alarms_log}.today
-		cmp -zs ${alarms_log}.yesterday ${alarms_log}.today
-		raid_rc=$?
-		if test $raid_rc -ne 0; then
+		old=$(mktemp /tmp/tmp.XXXXX)
+		new=$(mktemp /tmp/tmp.XXXXX)
+		sort < "${alarms_log}.yesterday" > "$old"
+		sort < "${alarms_log}.today" > "$new"
+		comm -13 "$old" "$new" | grep -q '[^[:space:]]'
+		file_diff=$?
+		rm -f "$old" "$new"
+		if [ "$file_diff" -ne 0 ]; then
+			raid_rc=0
+		else
+			raid_rc=1
 			diff -u ${alarms_log}.yesterday ${alarms_log}.today | \
 				grep -v '^-\|^$'
 		fi


### PR DESCRIPTION
This commit fixes a bug where we sent alerts when we had blank lines. The following cases have been covered:
1) If the old alarm file had some entries and the new one is empty or filled with whitespace, we donot send an alert for new alarms.
2) If the new alarm file is empty but the old alarm file has some alerts, we donot send an alert.
3) If the new alarm file does not have any additions of any alarm and is similar to the old alarm file or perhaps has only added blank lines, we donot send an alert.

Ticket: #NAS-101788