### PR TITLE
NAS-102252 / 11.3 / Add asigra jail image port

### DIFF
--- a/sysutils/asigrajail/Makefile
+++ b/sysutils/asigrajail/Makefile
@@ -1,0 +1,26 @@
+# $FreeBSD$
+
+PORTNAME=	asigrajail
+PORTVERSION=	1
+CATEGORIES=	sysutils
+MASTER_SITES=	https://asigra-f611.kxcdn.com/jail/
+DISTNAME=	asigra_migration_image_9b5802df_2019-07-19
+EXTRACT_SUFX=	.tar.xz
+
+EXTRACT_ONLY=
+
+MAINTAINER=	waqar@ixsystems.com
+COMMENT=	Award cloud backup and restore server application's plugin image
+
+NO_BUILD=	yes
+
+.include <bsd.port.pre.mk>
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/share/asigra
+	${CP} ${DISTDIR}/${DISTNAME}${EXTRACT_SUFX} ${STAGEDIR}${PREFIX}/share/asigra/
+	@${ECHO_CMD} "@dir share/asigra" >> ${TMPPLIST}
+	${FIND} -s ${STAGEDIR}${PREFIX}/share/asigra -not -type d | ${SORT} | \
+		${SED} -e 's#^${STAGEDIR}${PREFIX}/##' >> ${TMPPLIST}
+
+.include <bsd.port.post.mk>

--- a/sysutils/asigrajail/distinfo
+++ b/sysutils/asigrajail/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1563590563
+SHA256 (asigra_migration_image_9b5802df_2019-07-19.tar.xz) = 9da485bbacc1a06d9759f3a6a711b001ecf1d241ba1ed04b5c43fb99bd1efd68
+SIZE (asigra_migration_image_9b5802df_2019-07-19.tar.xz) = 116375628

--- a/sysutils/asigrajail/pkg-descr
+++ b/sysutils/asigrajail/pkg-descr
@@ -1,0 +1,3 @@
+Asigra plugin jail image.
+
+WWW: ixsystems.com


### PR DESCRIPTION
This commit adds asigra jail image port which we will use for having asigra plugin image builtin in the TN iso.