### PR TITLE
NAS-100417 / 12 / Bug fix for libvirt port

### DIFF
--- a/devel/libvirt/Makefile
+++ b/devel/libvirt/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	libvirt
 PORTVERSION=	5.5.0
+PORTREVISION=	1
 CATEGORIES=	devel
 MASTER_SITES=	http://libvirt.org/sources/ \
 		ftp://libvirt.org/libvirt/
@@ -91,6 +92,11 @@ CONFIGURE_ARGS+=	--without-avahi \
 
 # random_data fix can be removed when 8.x is eol
 CONFIGURE_ENV=	ac_cv_type_struct_random_data=""
+
+.if !exists(/sbin/zpool)
+BUILD_DEPENDS+=	openzfs>=0:sysutils/openzfs
+RUN_DEPENDS+=	openzfs>=0:sysutils/openzfs
+.endif
 
 # limit production release x.x.x
 PORTSCOUT=	limit:\d+\.\d+\.\d+$$


### PR DESCRIPTION
This commit fixes a bug where zfs binary couldn't be detected by libvirt port.