### PR TITLE
NAS-100109 / 12 / Don't stop libvirt via rc framework on shutdown

### DIFF
--- a/devel/libvirt/Makefile
+++ b/devel/libvirt/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	libvirt
 PORTVERSION=	5.5.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	devel
 MASTER_SITES=	http://libvirt.org/sources/ \
 		ftp://libvirt.org/libvirt/

--- a/devel/libvirt/files/libvirtd.in
+++ b/devel/libvirt/files/libvirtd.in
@@ -4,7 +4,6 @@
 #
 # PROVIDE: libvirtd
 # REQUIRE: LOGIN virtlogd
-# KEYWORD: shutdown
 #
 # Add the following line to /etc/rc.conf[.local] to enable libvirtd.
 #


### PR DESCRIPTION
This commit adds changes to ensure that we don't stop libvirt via rc framework when a system shutdown is initiated and instead make sure that middlewared takes responsibility for this.