### PR TITLE
NAS-103609 / 11.3 / #HQ-176 Disable native optimizations for fio

### DIFF
--- a/benchmarks/fio/Makefile
+++ b/benchmarks/fio/Makefile
@@ -13,6 +13,7 @@ LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		gmake tar:bzip2
+CONFIGURE_ARGS= --disable_native
 
 OPTIONS_DEFINE=	GNUPLOT EXAMPLES
 GNUPLOT_DESC=	Support for plotting graphs

--- a/benchmarks/fio/Makefile
+++ b/benchmarks/fio/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	fio
 PORTVERSION=	3.16
+PORTREVISION=	1
 CATEGORIES=	benchmarks
 MASTER_SITES=	http://brick.kernel.dk/snaps/
 


### PR DESCRIPTION
Since fio 3.6 people packaging fio(such as ports) have been instructed to disable native optimizations. This fixes that the freenas nightlies fio is broken on c3000 atoms among other platforms. 

https://github.com/axboe/fio/commit/a817dc3b3b5a0efc95aaca366875eac67607cd5b