### PR TITLE
Introduce 1 second sleep between mdnsd start and mdnsadvertise start

### DIFF
--- a/net/mDNSResponder/files/mdnsd.in
+++ b/net/mDNSResponder/files/mdnsd.in
@@ -21,6 +21,7 @@ stop_precmd="mdnsd_prestop"
 
 mdnsd_poststart() {
     echo "restarting mdnsadvertise."
+    sleep 1
     %%PREFIX%%/bin/midclt call mdnsadvertise.restart > /dev/null
 }
 


### PR DESCRIPTION
mdnsadvertise should not be started until mdnsd is fully started.
In testing a 1 second sleep in the rc post_start command is
sufficient to ensure that the services start properly on fresh
boot.