### PR TITLE
NAS-103609 / 11.3 / Nas-103609 / 11 / Disable native optimizations for fio

### DIFF
--- a/benchmarks/fio/Makefile
+++ b/benchmarks/fio/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	fio
 PORTVERSION=	3.16
+PORTREVISION=	1
 CATEGORIES=	benchmarks
 MASTER_SITES=	http://brick.kernel.dk/snaps/
 
@@ -12,7 +13,10 @@ COMMENT=	Flexible IO tester
 LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+HAS_CONFIGURE=	yes
 USES=		gmake tar:bzip2
+
+CONFIGURE_ARGS+=	--disable-native
 
 OPTIONS_DEFINE=	GNUPLOT EXAMPLES
 GNUPLOT_DESC=	Support for plotting graphs

--- a/benchmarks/fio/Makefile
+++ b/benchmarks/fio/Makefile
@@ -3,7 +3,6 @@
 
 PORTNAME=	fio
 PORTVERSION=	3.16
-PORTREVISION=	1
 CATEGORIES=	benchmarks
 MASTER_SITES=	http://brick.kernel.dk/snaps/
 
@@ -14,7 +13,6 @@ LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		gmake tar:bzip2
-CONFIGURE_ARGS= --disable_native
 
 OPTIONS_DEFINE=	GNUPLOT EXAMPLES
 GNUPLOT_DESC=	Support for plotting graphs

--- a/benchmarks/fio/Makefile
+++ b/benchmarks/fio/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	fio
 PORTVERSION=	3.16
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	benchmarks
 MASTER_SITES=	http://brick.kernel.dk/snaps/
 


### PR DESCRIPTION
Since fio 3.6 people packaging fio(such as ports) have been instructed to disable native optimizations. This fixes that the freenas nightlies fio is broken on c3000 atoms among other platforms.

axboe/fio@a817dc3
 
This commit also reverts previous attempt at this patch and pulls in upstream ports fix