### PR TITLE
NAS-103742 / 11.3 / devel/py-remote-pdb: Remote vanilla PDB (over TCP sockets) done right

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -4984,6 +4984,7 @@
     SUBDIR += py-rebulk
     SUBDIR += py-rednose
     SUBDIR += py-rekall-efilter
+    SUBDIR += py-remote-pdb
     SUBDIR += py-repoze.lru
     SUBDIR += py-repoze.sphinx.autointerface
     SUBDIR += py-repoze.tm2

--- a/devel/py-remote-pdb/Makefile
+++ b/devel/py-remote-pdb/Makefile
@@ -1,0 +1,19 @@
+# $FreeBSD$
+
+PORTNAME=	remote-pdb
+PORTVERSION=	2.0.0
+CATEGORIES=	devel python
+MASTER_SITES=	CHEESESHOP
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	python@FreeBSD.org
+COMMENT=	Remote vanilla PDB over TCP sockets
+
+LICENSE=	BSD2CLAUSE
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+USES=		python
+USE_PYTHON=	autoplist concurrent distutils
+NO_ARCH=	yes
+
+.include <bsd.port.mk>

--- a/devel/py-remote-pdb/distinfo
+++ b/devel/py-remote-pdb/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1572625786
+SHA256 (remote-pdb-2.0.0.tar.gz) = ad38f36f539b22be820f94062618366d5d3461115c1605b11679dba75f94ee62
+SIZE (remote-pdb-2.0.0.tar.gz) = 18410

--- a/devel/py-remote-pdb/pkg-descr
+++ b/devel/py-remote-pdb/pkg-descr
@@ -1,0 +1,5 @@
+Remote vanilla PDB (over TCP sockets) done right.
+
+No extras, proper handling around connection failures and CI. Based on pdbx.
+
+WWW: https://github.com/ionelmc/python-remote-pdb


### PR DESCRIPTION
No extras, proper handling around connection failures and CI. Based on pdbx.

WWW: https://github.com/ionelmc/python-remote-pdb