### PR TITLE
Add functions to take, delete, and rollback snapshots to smblibzfs

### DIFF
--- a/net/samba410/files/0001-add-ix-custom-vfs-modules.patch
+++ b/net/samba410/files/0001-add-ix-custom-vfs-modules.patch
@@ -1,9 +1,9 @@
 diff --git a/source3/modules/smb_libzfs.c b/source3/modules/smb_libzfs.c
 new file mode 100644
-index 0000000..5960fcd
+index 0000000..e3ae9f7
 --- /dev/null
 +++ b/source3/modules/smb_libzfs.c
-@@ -0,0 +1,711 @@
+@@ -0,0 +1,969 @@
 +/*-
 + * Copyright 2018 iXsystems, Inc.
 + * All rights reserved
@@ -35,8 +35,11 @@ index 0000000..5960fcd
 +#include <talloc.h>
 +#include <sys/types.h>
 +#include <sys/time.h>
++#include <sys/nvpair.h>
 +#include <libzfs.h>
++#include <fnmatch.h>
 +#include "lib/util/debug.h"
++#include "lib/util/dlinklist.h"
 +#include "smb_macros.h"
 +#include "modules/smb_libzfs.h"
 +
@@ -45,6 +48,7 @@ index 0000000..5960fcd
 +#endif
 +
 +#define SHADOW_COPY_ZFS_GMT_FORMAT "@GMT-%Y.%m.%d-%H.%M.%S"
++#define ZFS_PROP_SAMBA_PREFIX "org.samba"
 +
 +enum SMB_QUOTA_TYPE {
 +	SMB_INVALID_QUOTA_TYPE = -1,
@@ -68,6 +72,22 @@ index 0000000..5960fcd
 +
 +struct smblibzfs_int {
 +	libzfs_handle_t *libzfsp;
++};
++
++struct iter_info
++{
++	bool ignore_empty_snaps;
++	const char **inclusions;
++	const char **exclusions;
++	time_t start;
++	time_t end;
++};
++
++struct snap_cb
++{
++	TALLOC_CTX *mem_ctx;
++	struct snapshot_list *snapshots;
++	struct iter_info *iter_info;
 +};
 +
 +static int get_enum(const char *s, const struct enum_list *_enum)
@@ -118,10 +138,8 @@ index 0000000..5960fcd
 +	return 0;
 +}
 +
-+int 
-+smb_zfs_path_to_dataset(struct smblibzfshandle *smblibzfsp,
-+			const char *pathname,
-+			const char **dataset_name_out)
++static zfs_handle_t *get_zhandle(struct smblibzfshandle *smblibzfsp,
++				 const char *path)
 +{
 +	zfs_handle_t *zfsp = NULL;
 +	struct smblibzfs_int *slibzp_int = NULL;
@@ -129,24 +147,73 @@ index 0000000..5960fcd
 +					   struct smblibzfs_int);
 +	if (slibzp_int == NULL) {
 +		DBG_ERR("Failed to retrieve smblibzfs_int handle\n");
-+		return -1;
++		return zfsp;
 +	}
 +
-+	if (pathname == NULL) {
++	if (path == NULL) {
 +		DBG_ERR("No pathname provided\n");
-+		return (-1);
++		return zfsp;
 +	}
-+
-+	zfsp = zfs_path_to_zhandle(slibzp_int->libzfsp, pathname,
++	zfsp = zfs_path_to_zhandle(slibzp_int->libzfsp, path,
 +		ZFS_TYPE_VOLUME|ZFS_TYPE_DATASET|ZFS_TYPE_FILESYSTEM);
++
++	if (zfsp == NULL) {
++		DBG_ERR("Failed to obtain zhandle on parent directory: (%s)\n",
++			path);
++	}
++	return zfsp;
++}
++
++int 
++smb_zfs_path_to_dataset(struct smblibzfshandle *smblibzfsp,
++			const char *pathname,
++			const char **dataset_name_out)
++{
++	zfs_handle_t *zfsp = NULL;
++	zfsp = get_zhandle(smblibzfsp, pathname);
 +
 +	if (zfsp == NULL) {
 +		DBG_ERR("Failed to obtain zhandle on parent directory: (%s)\n",
 +			pathname);
 +		return -1;
 +	}
++
 +	*dataset_name_out = zfs_get_name(zfsp);
 +	zfs_close(zfsp);
++	return 0;
++}
++
++int
++smb_zfs_dataset_name_to_mp(struct smblibzfshandle *smblibzfsp,
++			   TALLOC_CTX *mem_ctx,
++			   const char *dataset_name,
++			   char **dataset_mp_out)
++{
++	int ret;
++	struct smblibzfs_int *slibzp_int = NULL;
++	zfs_handle_t *zfsp = NULL;
++	*dataset_mp_out = talloc_zero_size(mem_ctx, PATH_MAX);
++	slibzp_int = talloc_get_type_abort(smblibzfsp->private,
++					   struct smblibzfs_int);
++	if (slibzp_int == NULL) {
++		DBG_ERR("Failed to retrieve smblibzfs_int handle\n");
++		return -1;
++	}
++	zfsp = zfs_open(slibzp_int->libzfsp, dataset_name, ZFS_TYPE_DATASET);
++	if (zfsp == NULL) {
++		DBG_ERR("Failed to get zfs handle for %s: %s\n",
++			dataset_name, strerror(errno));
++		return -1;
++	}
++	ret = zfs_prop_get(zfsp, ZFS_PROP_MOUNTPOINT, *dataset_mp_out,
++			   talloc_get_size(*dataset_mp_out), NULL, NULL,
++			   0, 0);
++	if (ret != 0) {
++		DBG_ERR("Failed to get mountpoint for %s: %s\n",
++			dataset_name, strerror(errno));
++		zfs_close(zfsp);
++		return -1;
++	}
 +	return 0;
 +}
 +
@@ -160,8 +227,8 @@ index 0000000..5960fcd
 +	size_t blocksize = 1024;
 +	struct smblibzfs_int *slibzp_int = NULL;
 +	zfs_handle_t *zfsp = NULL;
-+	char u_req[256] = { 0 };
-+	char q_req[256] = { 0 };
++	char u_req[ZFS_MAXPROPLEN] = { 0 };
++	char q_req[ZFS_MAXPROPLEN] = { 0 };
 +	uint64_t quota, used; 
 +	quota = used = 0;
 +	slibzp_int = talloc_get_type_abort(smblibzfsp->private,
@@ -351,21 +418,6 @@ index 0000000..5960fcd
 +	return (*dfree);
 +}
 +
-+/*
-+ * This function creates a child dataset of a specified parent dataset.
-+ * Realpath of parent dataset should be passed into the function. Name
-+ * of child dataset is expected to be relative to parent dataset. I.e.
-+ * if parent datset is tank/share and you wish to create tank/share/sub1
-+ * then the expected name of the child dataset is "sub1". Aclmode
-+ * will be inherited from parent.
-+ *
-+ * @param[in]	smblibzfsp		smblibzfs handle struct
-+ * @param[in]	parent			realpath to parent dataset
-+ * @param[in]	base			name of child dataset.
-+ * @param[in]	quota			ZFS dataset quota
-+ *
-+ * @return	0 on success -1 on failure. 
-+ */
 +int
 +smb_zfs_create_child_dataset(struct smblibzfshandle *smblibzfsp,
 +			     char *parent, const char *base,
@@ -401,7 +453,7 @@ index 0000000..5960fcd
 +		DBG_ERR("Failed to create dataset to path (%s)\n", nd);
 +		zfs_close(zfsp);
 +		return (-1);
-+	} 
++	}
 +	zfs_close(zfsp);
 +
 +	new_zfsp = zfs_open(slibzp_int->libzfsp, nd, ZFS_TYPE_DATASET);
@@ -418,7 +470,6 @@ index 0000000..5960fcd
 +	if (zfs_prop_inherit(new_zfsp, zfs_prop_to_name(ZFS_PROP_ACLMODE), B_FALSE) < 0){
 +		DBG_ERR("Failed to inherit aclmode from parent dataset\n");
 +	}
-+
 +	if (quota) {
 +		if (zfs_prop_set(new_zfsp, "quota", quota) != 0) {
 +			DBG_ERR("Failed to set quota to (%s)\n", quota);
@@ -432,6 +483,125 @@ index 0000000..5960fcd
 +}
 +
 +int
++smb_zfs_get_user_prop(struct smblibzfshandle *smblibzfsp,
++		      TALLOC_CTX *mem_ctx,
++		      const char *path,
++		      const char *prop,
++		      char **value)
++{
++	int ret;
++	zfs_handle_t *zfsp = NULL;
++	struct smblibzfs_int *slibzp_int = NULL;
++	nvlist_t *userprops = NULL;
++	nvlist_t *propval = NULL;
++	char *propstr = NULL;
++	char *prefixed_prop = NULL;
++
++	zfsp = get_zhandle(smblibzfsp, path);
++	if (zfsp == NULL) {
++		DBG_ERR("Failed to obtain zhandle on path: (%s)\n", path);
++		return -1;
++	}
++	userprops = zfs_get_user_props(zfsp);
++	prefixed_prop = talloc_asprintf(mem_ctx, "%s:%s", 
++					ZFS_PROP_SAMBA_PREFIX,
++					prop);
++	ret = nvlist_lookup_nvlist(userprops, prefixed_prop, &propval);
++	if (ret != 0) {
++		DBG_INFO("Failed to look up custom user property %s "
++			 "on path [%s]: %s\n", prop, path, strerror(errno));
++		zfs_close(zfsp);
++		return -1;	
++	}
++	ret = nvlist_lookup_string(propval, ZPROP_VALUE, &propstr);
++	TALLOC_FREE(prefixed_prop);
++	if (ret != 0) {
++		DBG_ERR("Failed to get nvlist string for property %s\n",
++			prop); 
++		zfs_close(zfsp);
++		return -1;	
++	}
++	*value = talloc_strdup(mem_ctx, propstr);
++	zfs_close(zfsp);
++	return 0;
++}
++
++int
++smb_zfs_set_user_prop(struct smblibzfshandle *smblibzfsp,
++		      const char *path,
++		      const char *prop,
++		      const char *value)
++{
++	int ret;
++	zfs_handle_t *zfsp = NULL;
++	char prefixed_prop[ZFS_MAXPROPLEN] = {0};
++
++	zfsp = get_zhandle(smblibzfsp, path);
++
++	if (zfsp == NULL) {
++		DBG_ERR("Failed to obtain zhandle on path: (%s)\n", path);
++		return -1;
++	}
++
++	ret = snprintf(prefixed_prop, sizeof(prefixed_prop), "%s:%s",
++		       ZFS_PROP_SAMBA_PREFIX, prop);
++	if (ret < 0) {
++		DBG_ERR("Failed to generate property name: %s",
++			strerror(errno));
++		zfs_close(zfsp);
++		return -1;
++	}
++
++	ret = zfs_prop_set(zfsp, prefixed_prop, value);
++	if (ret != 0) {
++		DBG_ERR("Failed to set property [%s] on path [%s] to [%s]\n",
++			prefixed_prop, path, value);
++	}
++
++	zfs_close(zfsp);
++	return ret;
++}
++
++int
++smb_zfs_path_get_props(struct smblibzfshandle *smblibzfsp,
++		       const char *path,
++		       struct zfs_dataset_prop **pprop)
++{
++	int casesens = 0;
++	int ret;
++	char buf[ZFS_MAXPROPLEN];
++	char source[ZFS_MAX_DATASET_NAME_LEN];
++	zprop_source_t sourcetype;
++	zfs_handle_t *zfsp = NULL;
++	struct zfs_dataset_prop *props = NULL;
++	props = *pprop;
++
++	zfsp = get_zhandle(smblibzfsp, path);
++	if (zfsp == NULL) {
++		DBG_ERR("Failed to obtain zhandle on [%s]: %s\n",
++			path, strerror(errno));
++		return -1;
++	}
++	if (zfs_prop_get(zfsp, ZFS_PROP_CASE,
++	    buf, sizeof(buf), &sourcetype, 
++	    source, sizeof(source), B_FALSE) != 0) {
++		DBG_ERR("Failed to look up casesensitivity propertiy on path: (%s)\n",
++			path);
++		zfs_close(zfsp);
++		return -1;
++	}
++	props->casesens = get_enum(buf, casesensitivity);
++	props->readonly = zfs_prop_get_int(zfsp, ZFS_PROP_READONLY);
++#if 0 /* properties we may wish to return in the future */
++	props->exec = zfs_prop_get_int(zfsp, ZFS_PROP_EXEC);
++	props->atime = zfs_prop_get_int(zfsp, ZFS_PROP_ATIME);
++	props->setuid = zfs_prop_get_int(zfsp, ZFS_PROP_SETUID);
++#endif
++	zfs_close(zfsp);
++	return 0;
++}
++
++int
 +smb_zfs_get_case_sensitivity(struct smblibzfshandle *smblibzfsp, char* path)
 +{
 +	int casesens = 0;
@@ -439,22 +609,8 @@ index 0000000..5960fcd
 +	char source[ZFS_MAX_DATASET_NAME_LEN];
 +	zprop_source_t sourcetype;
 +	zfs_handle_t *zfsp = NULL;
-+	struct smblibzfs_int *slibzp_int = NULL;
 +
-+	slibzp_int = talloc_get_type_abort(smblibzfsp->private,
-+					   struct smblibzfs_int);
-+	if (slibzp_int == NULL) {
-+		DBG_ERR("Failed to retrieve smblibzfs_int handle\n");
-+		return -1;
-+	}
-+
-+	if (path == NULL) {
-+		return (-1);
-+	}
-+
-+	zfsp = zfs_path_to_zhandle(slibzp_int->libzfsp, path,
-+		ZFS_TYPE_VOLUME|ZFS_TYPE_DATASET|ZFS_TYPE_FILESYSTEM);
-+
++	zfsp = get_zhandle(smblibzfsp, path);
 +	if (zfsp == NULL) {
 +		DBG_ERR("Failed to obtain zhandle on path: (%s)\n", path);
 +		return (-1);
@@ -487,16 +643,16 @@ index 0000000..5960fcd
 +	}
 +
 +	if (*info->inclusions && !*pattern) {
-+		DEBUG(2,("smb_zfs_add_snapshot: snapshot %s "
-+		    "not in inclusion list\n", snap_name));
++		DBG_INFO("smb_zfs_add_snapshot: snapshot %s "
++			    "not in inclusion list\n", snap_name);
 +		return false;
 +	}
 +
 +	pattern = info->exclusions;
 +	while (*pattern) {
 +		if (unix_wild_match(*pattern, snap_name)) {
-+			DEBUG(2,("smb_zfs_add_snapshot: snapshot %s "
-+			    "in exclusion list\n", snap_name));
++			DBG_INFO("smb_zfs_add_snapshot: snapshot %s "
++				    "in exclusion list\n", snap_name);
 +			return false;
 +		}
 +		pattern++;
@@ -508,147 +664,90 @@ index 0000000..5960fcd
 +static int
 +smb_zfs_add_snapshot(zfs_handle_t *snap, void *data)
 +{
-+	struct iter_info *info = NULL;
++	struct snap_cb *state = NULL;
 +	struct snapshot_entry *entry = NULL;
 +	const char *snap_name;
-+	char ts_buf[20];
-+	time_t timestamp_t;
++	time_t cr_time;
 +	struct tm timestamp;
 +	int rc, used;
 +	size_t req_mem, name_len;
 +
-+	if (unlikely(data == NULL)) {
-+		DBG_ERR("received NULL for data\n");
++	state = talloc_get_type_abort(data, struct snap_cb);
++	if (state == NULL) {
++		DBG_ERR("failed to get snap_cb private data\n");
++		zfs_close(snap);
 +		errno = ENOMEM;
 +		return -1;
 +	}
-+	info = (struct iter_info *) data;
 +
 +	/* ignore excluded snapshots */
 +	snap_name = strchr(zfs_get_name(snap), '@') + 1;
 +
-+	if (!shadow_copy_zfs_is_snapshot_included(info, snap_name)) {
++	if (!shadow_copy_zfs_is_snapshot_included(state->iter_info, snap_name)) {
 +		zfs_close(snap);
 +		return 0;
 +	}
 +
-+	if (info->ignore_empty_snaps) {
++	if (state->iter_info->ignore_empty_snaps) {
 +		used = zfs_prop_get_int(snap, ZFS_PROP_USED);
 +		if (used == 0) {
 +			zfs_close(snap);
 +			return 0;
 +		}
 +	}
++	cr_time = zfs_prop_get_int(snap, ZFS_PROP_CREATION);
 +
-+	/* get creation date */
-+	rc = zfs_prop_get(snap, ZFS_PROP_CREATION, ts_buf, sizeof(ts_buf),
-+			  NULL, NULL, 0, 1);
-+	if (rc != 0) {
-+		DEBUG(0,("smb_zfs_add_snapshot: error getting "
-+		    "creation date: %s\n", strerror(errno)));
-+
++	if (state->iter_info->start && state->iter_info->start > cr_time) {
 +		zfs_close(snap);
-+		return -2;
++		return 0;
++	}
++	if (state->iter_info->end && state->iter_info->end < cr_time) {
++		zfs_close(snap);
++		return 0;
 +	}
 +
-+	sscanf(ts_buf, "%lu", &timestamp_t);
++	entry = talloc_zero(state->mem_ctx, struct snapshot_entry);
 +
-+	/* expand list if necessary */
-+	req_mem = sizeof(*info->snapshots) +
-+		  info->snapshots->num_entries *
-+		  sizeof(info->snapshots->entries[0]);
-+
-+	if (req_mem > talloc_get_size(info->snapshots)) {
-+		req_mem += info->snapshots->num_entries / 2 *
-+			   sizeof(info->snapshots->entries[0]);
-+		info->snapshots = TALLOC_REALLOC(talloc_parent(info->snapshots),
-+						 info->snapshots, req_mem);
-+		if (info->snapshots == NULL) {
-+			DEBUG(0,("smb_zfs_add_snapshot: out of memory "
-+			    "(requested %zu bytes)\n", req_mem));
-+
-+			zfs_close(snap);
-+			return -2;
-+		}
-+	}
-+
-+	/* add entry */
 +	name_len = strlen(snap_name);
-+
-+	entry = talloc_size(info->snapshots, sizeof(*entry) + name_len);
-+	if (entry == NULL) {
-+		DEBUG(0,("smb_zfs_add_snapshot: out of memory "
-+		    "(requested %lu bytes)\n", sizeof(*entry) + name_len));
-+
-+		zfs_close(snap);
-+		errno = ENOMEM;
-+		return -2;
-+	}
-+
-+	info->snapshots->entries[info->snapshots->num_entries++] = entry;
-+
-+	gmtime_r(&timestamp_t, &timestamp);
++	gmtime_r(&cr_time, &timestamp);
 +	strftime(entry->label, sizeof(entry->label), SHADOW_COPY_ZFS_GMT_FORMAT,
 +		 &timestamp);
 +
-+	strlcpy(entry->name, snap_name, name_len + 1);
-+
++	entry->cr_time = cr_time;
++	entry->name = talloc_strndup(state->mem_ctx, snap_name, name_len +1);
++	DLIST_ADD(state->snapshots->entries, entry);
++	state->snapshots->num_entries++;
 +	zfs_close(snap);
 +	return 0;
 +}
 +
-+
-+/*
-+ * This function lists ZFS snapshots
-+ * @param[in]	smblibzfsp		smblibzfs handle struct
-+ * @param[in]	mem_ctx			TALLOC memory context
-+ * @param[in]	ignore_empty_snaps	ignore snapshots with zero space used
-+ * @param[in]	inclusions		list of filters to determine whether to
-+ *					include a snapshot in the list
-+ * @param[in]	exclusions		list of filters to determine whether to
-+ *					exclude a snapshot from the resulting list
-+ *
-+ * @return	struct snapshot_list
-+ */
 +struct
 +snapshot_list *smb_zfs_list_snapshots(struct smblibzfshandle *smblibzfsp,
 +				      TALLOC_CTX *mem_ctx,
 +				      const char *path,
 +				      bool ignore_empty_snaps,
 +				      const char **inclusions,
-+				      const char **exclusions)
++				      const char **exclusions,
++				      time_t start,
++				      time_t end)
 +{
-+	struct snapshot_list *snapshots = NULL;
++	struct snap_cb *state = NULL;
 +	struct iter_info iter_info;
 +	size_t initial_size;
 +	zfs_handle_t *zfs = NULL;
-+	struct smblibzfs_int *slibzp_int = NULL;
-+	char dataset_name = NULL;
 +	int rc;
-+	slibzp_int = talloc_get_type_abort(smblibzfsp->private,
-+					   struct smblibzfs_int);
-+	if (slibzp_int == NULL) {
-+		DBG_ERR("Failed to retrieve smblibzfs_int handle\n");
-+		return snapshots;
-+	}
 +
 +	/* initialize our result */
-+	initial_size = sizeof(*snapshots) + 10 * sizeof(snapshots->entries[0]);
-+	snapshots = talloc_size(mem_ctx, initial_size);
-+
-+	if (snapshots == NULL) {
-+		DEBUG(0,("smb_zfs_list_snapshots: out of memory"
-+		    "(requested %zu bytes)\n", initial_size));
++	state = talloc_zero(mem_ctx, struct snap_cb);
++	if (state == NULL) {
++		DBG_ERR("smb_zfs_list_snapshots: out of memory");
 +		goto done;
 +	}
++	state->snapshots = talloc_zero(mem_ctx, struct snapshot_list);
++	state->iter_info = talloc_zero(mem_ctx, struct iter_info);
++		
 +
-+	snapshots->mountpoint = NULL;
-+	snapshots->dataset_name = NULL;
-+	snapshots->num_entries = 0;
-+
-+	zfs = zfs_path_to_zhandle(slibzp_int->libzfsp, path,
-+		ZFS_TYPE_VOLUME|ZFS_TYPE_DATASET|ZFS_TYPE_FILESYSTEM);
-+
++	zfs = get_zhandle(smblibzfsp, path);
 +	if (zfs == NULL) {
 +		DBG_ERR("smb_zfs_list_snapshots: error getting "
 +			"zhandle from path '%s' (%s)\n", path, strerror(errno));
@@ -656,71 +755,230 @@ index 0000000..5960fcd
 +	}
 +
 +	/* get mountpoint */
-+	snapshots->mountpoint = talloc_size(snapshots, ZFS_MAXPROPLEN + 1);
-+	snapshots->dataset_name = talloc_strdup(mem_ctx, zfs_get_name(zfs));
++	state->snapshots->dataset_name = zfs_get_name(zfs);
 +
-+	if (snapshots->mountpoint == NULL) {
-+		DEBUG(0,("smb_zfs_list_snapshots: out of memory "
-+		    "(requested %d bytes)\n",  ZFS_MAXPROPLEN + 1));
-+		goto error;
-+	}
-+
-+	rc = zfs_prop_get(zfs, ZFS_PROP_MOUNTPOINT, snapshots->mountpoint,
-+			  talloc_get_size(snapshots->mountpoint), NULL, NULL,
++	rc = zfs_prop_get(zfs, ZFS_PROP_MOUNTPOINT, state->snapshots->mountpoint,
++			  talloc_get_size(state->snapshots->mountpoint), NULL, NULL,
 +			  0, 0);
 +
 +	if (rc != 0) {
-+		DEBUG(0,("smb_zfs_list_snapshots: error getting "
-+		    "mountpoint for '%s': %s\n", path, strerror(errno)));
++		DBG_ERR("smb_zfs_list_snapshots: error getting "
++			"mountpoint for '%s': %s\n", path, strerror(errno));
 +		goto error;
 +	}
 +
 +	/* get snapshots */
-+	iter_info.snapshots = snapshots;
-+	iter_info.inclusions = inclusions;
-+	iter_info.exclusions = exclusions;
-+	iter_info.ignore_empty_snaps = ignore_empty_snaps;
++	state->iter_info->inclusions = inclusions;
++	state->iter_info->exclusions = exclusions;
++	state->iter_info->ignore_empty_snaps = ignore_empty_snaps;
++	state->iter_info->start = start;
++	state->iter_info->end = end;
 +
-+	if (iter_info.inclusions == NULL) {
-+		DEBUG(0,("smb_zfs_list_snapshots: error getting "
-+		    "shadow:include parameter\n"));
++	if (state->iter_info->inclusions == NULL) {
++		DBG_ERR("smb_zfs_list_snapshots: error getting "
++			"shadow:include parameter\n");
 +		goto error;
 +	}
 +
-+	if (iter_info.exclusions == NULL) {
-+		DEBUG(0,("smb_zfs_list_snapshots: error getting "
-+		    "shadow:exclude parameter\n"));
++	if (state->iter_info->exclusions == NULL) {
++		DBG_ERR("smb_zfs_list_snapshots: error getting "
++			"shadow:exclude parameter\n");
 +		goto error;
 +	}
 +
-+	rc = zfs_iter_snapshots(zfs, false, smb_zfs_add_snapshot, &iter_info);
++	rc = zfs_iter_snapshots(zfs, false, smb_zfs_add_snapshot, state);
 +
 +	if (rc != 0) {
-+		DEBUG(0,("smb_zfs_list_snapshots: error getting "
-+		    "snapshots for '%s': %s\n", path, strerror(errno)));
++		DBG_ERR("smb_zfs_list_snapshots: error getting "
++			"snapshots for '%s': %s\n", path, strerror(errno));
 +		goto error;
 +	}
 +
-+	snapshots = iter_info.snapshots;
-+	time(&snapshots->timestamp);
++	time(&state->snapshots->timestamp);
 +
 +	goto done;
 +
 +error:
-+	TALLOC_FREE(snapshots);
++	TALLOC_FREE(state);
 +
 +done:
 +	if (zfs)
 +		zfs_close(zfs);
 +
-+	return snapshots;
++	return state->snapshots;
++}
++
++/*
++ * Convert linked list to nvlist and perform delete in single
++ * consolidated ioctl.
++ */
++int
++smb_zfs_delete_snapshots(struct smblibzfshandle *smblibzfsp,
++			 TALLOC_CTX *mem_ctx,
++			 struct snapshot_list *snaps)
++{
++	int ret;
++	nvlist_t *to_delete = NULL;
++	struct smblibzfs_int *slibzp_int = NULL;
++	struct snapshot_entry *entry = NULL;
++	char *snapname = NULL;
++	slibzp_int = talloc_get_type_abort(smblibzfsp->private,
++					   struct smblibzfs_int);
++	if (slibzp_int == NULL) {
++		errno=ENOMEM;
++		DBG_ERR("Unable to re-use libzfs handle\n");
++		return -1;
++	}
++	ret = nvlist_alloc(&to_delete, NV_UNIQUE_NAME, 0);
++	if (ret != 0) {
++		DBG_ERR("Failed to initialize nvlist for snaps.\n");
++		errno=ENOMEM;
++		return -1;
++	}
++	for (entry = snaps->entries; entry; entry = entry->next) {
++		snapname = talloc_asprintf(mem_ctx,
++					   "%s@%s",
++					   snaps->dataset_name,
++					   entry->name);
++		DBG_INFO("deleting snapshot: %s\n", snapname);
++		fnvlist_add_boolean(to_delete, snapname);
++		TALLOC_FREE(snapname);
++	}
++	ret = zfs_destroy_snaps_nvl(slibzp_int->libzfsp,
++				    to_delete,
++				    B_TRUE);
++	if (ret !=0) {
++		DBG_ERR("Failed to delete snapshots\n");
++		return ret;
++	}
++	return 0;
++}
++
++/*
++ * Create snapshot with specified name on specified dataset.
++ */
++int
++smb_zfs_snapshot(struct smblibzfshandle *smblibzfsp,
++		 const char *path,
++		 const char *snapshot_name,
++		 bool recursive)
++{
++	int ret;
++	struct smblibzfs_int *slibzp_int = NULL;
++	zfs_handle_t *zfsp = NULL;
++	char snap[ZFS_MAXPROPLEN] = {0};
++	const char *dataset_name;
++
++	slibzp_int = talloc_get_type_abort(smblibzfsp->private,
++					   struct smblibzfs_int);
++	if (slibzp_int == NULL) {
++		errno=ENOMEM;
++		return -1;
++	}
++	
++	zfsp = get_zhandle(smblibzfsp, path);
++	if (zfsp == NULL) {
++		DBG_ERR("Failed to obtain zhandle on path: (%s)\n",
++			path);
++		return -1;
++	}
++	dataset_name = zfs_get_name(zfsp);
++	zfs_close(zfsp);
++	ret = snprintf(snap, sizeof(snap), "%s@%s",
++		       dataset_name, snapshot_name);
++	if (ret < 0) {
++		DBG_ERR("Failed to format snapshot name:%s\n",
++			strerror(errno));
++		return -1;
++	}
++	ret = zfs_snapshot(slibzp_int->libzfsp,
++			   snap, recursive, NULL);
++	if (ret != 0) {
++		DBG_ERR("Failed to create snapshot %s: [%s]\n",
++			snap, strerror(errno));
++	}
++	DBG_INFO("Successfully created snapshot: %s\n", snap);
++	return ret;
++}
++
++/*
++ * Roll back to specified snapshot
++ */
++int
++smb_zfs_rollback(struct smblibzfshandle *smblibzfsp,
++		 const char *path,
++		 const char *snapshot_name,
++		 bool force)
++{
++	int ret;
++	struct smblibzfs_int *slibzp_int = NULL;
++	zfs_handle_t *dataset_handle = NULL;
++	zfs_handle_t *snap_handle = NULL;
++
++	slibzp_int = talloc_get_type_abort(smblibzfsp->private,
++					   struct smblibzfs_int);
++	if (slibzp_int == NULL) {
++		errno=ENOMEM;
++		return -1;
++	}
++
++	dataset_handle = get_zhandle(smblibzfsp, path);
++	if (dataset_handle == NULL) {
++		DBG_ERR("Failed to obtain zhandle on path: (%s)\n",
++			path);
++		return -1;
++	}
++
++	snap_handle = zfs_open(slibzp_int->libzfsp, snapshot_name,
++			       ZFS_TYPE_DATASET);
++	if (snap_handle == NULL) {
++		DBG_ERR("Failed to obtain zhandle for snap: (%s)\n",
++			snapshot_name);
++		zfs_close(dataset_handle);
++		return -1;
++	}
++	ret = zfs_rollback(dataset_handle, snap_handle, force);
++	if (ret != 0) {
++		DBG_ERR("Failed to roll back %s to snapshot %s\n",
++			path, snapshot_name);
++	}
++	zfs_close(dataset_handle);
++	zfs_close(snap_handle);
++	return ret;	
++}
++
++/*
++ * Roll back to last snapshot
++ */
++int
++smb_zfs_rollback_last(struct smblibzfshandle *smblibzfsp,
++		      const char *path)
++{
++	int ret;
++	zfs_handle_t *dataset_handle = NULL;
++	const char *dataset_name;
++
++	dataset_handle = get_zhandle(smblibzfsp, path);
++	if (dataset_handle == NULL) {
++		DBG_ERR("Failed to obtain zhandle on path: (%s)\n",
++			path);
++		return -1;
++	}
++	dataset_name = zfs_get_name(dataset_handle);
++
++	ret = lzc_rollback(dataset_name, NULL, 0);
++	if (ret != 0) {
++		DBG_ERR("Failed to roll back snapshot on %s\n", path);
++	}
++	zfs_close(dataset_handle);
++	return ret;	
 +}
 diff --git a/source3/modules/smb_libzfs.h b/source3/modules/smb_libzfs.h
 new file mode 100644
-index 0000000..0378541
+index 0000000..d580233
 --- /dev/null
 +++ b/source3/modules/smb_libzfs.h
-@@ -0,0 +1,95 @@
+@@ -0,0 +1,309 @@
 +/*-
 + * Copyright 2018 iXsystems, Inc.
 + * All rights reserved
@@ -757,63 +1015,277 @@ index 0000000..0378541
 +	void *private;
 +};
 +
-+struct iter_info
-+{
-+    struct snapshot_list *snapshots;
-+    bool ignore_empty_snaps;
-+    const char **inclusions;
-+    const char **exclusions;
-+};
-+
 +struct snapshot_entry
 +{
-+    char label[25];
-+    char name[1];
-+    struct snapshot_entry *prev, *next;
++	char label[25];		/* @GMT-prefixed label for snapshot */
++	char *name;		/* name of snapshot */
++	time_t cr_time;		/* creation time of snapshot */
++	struct snapshot_entry *prev, *next;
 +};
 +
 +struct snapshot_list
 +{
-+    time_t timestamp;
-+    char *mountpoint;
-+    char *dataset_name;
-+    int (*cmpfunc)(const void *, const void *);
-+    size_t num_entries;
-+    struct snapshot_entry *entries[1];
++	time_t timestamp;	/* when list generated */
++	char *mountpoint;	/* mountpoint of ZFS dataset where list taken */
++	char *dataset_name;	/* ZFS dataset name that the list is for */
++	size_t num_entries;	/* number of entries in snapshot list */
++	struct snapshot_entry *entries;
 +};
-+
 +
 +enum casesensitivity {SMBZFS_SENSITIVE, SMBZFS_INSENSITIVE, SMBZFS_MIXED};
 +
 +struct zfs_dataset_prop
 +{
-+	enum casesensitivity *casesens;
-+	bool readonly;
++	enum casesensitivity casesens;
++	int readonly;
++#if 0 /* Properties we may wish to expose in the future */
++	int atime;
++	int exec;
++	int setuid;
++#endif
 +};
 +
++/*
++ * Get an smblibzfshandle. This is to allow reuse of the same libzfs handle,
++ * which provides performance and efficiency benefits. The libzfs handle will
++ * be automatically closed in the destructor function for the smblibzfshandle.
++ *
++ * @param[in]	mem_ctx			talloc memory context
++ * @param[out]	smblibzfsp		smblibzfs handle struct
++ *
++ * @return	0 on success -1 on failure
++ */
 +
-+int get_smblibzfs_handle(TALLOC_CTX *mem_ctx, struct smblibzfshandle **smblibzfsp);
++int get_smblibzfs_handle(TALLOC_CTX *mem_ctx,struct smblibzfshandle **smblibzfsp);
 +
++/*
++ * Get dataset name for a given path. This is useful because there may be
++ * multiple ZFS datasets within a single SMB share.
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	pathname	 	full path in which to get dataset name.
++ * @param[out]	dataset_name_out	name of ZFS dataset
++ *
++ * @return	0 on success -1 on failure
++ */
 +int smb_zfs_path_to_dataset(struct smblibzfshandle *smblibzfsp,
-+			    const char *pathname, const char **dataset_name_out);
++			    const char *pathname,
++			    const char **dataset_name_out);
 +
-+int smb_zfs_get_userspace_quota(struct smblibzfshandle *smblibzfsp, char *path,
-+				int64_t xid, int quota_type, uint64_t *hardlimit,
++/*
++ * Get dataset name for a given path. This is useful because there may be
++ * multiple ZFS datasets within a single SMB share.
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	mem_ctx			talloc memory context
++ * @param[in]	dataset_name		name of ZFS dataset.
++ * @param[out]	dataset_mp_out		mountpoint of ZFS dataset (talloc'ed string).
++ *	
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_dataset_name_to_mp(struct smblibzfshandle *smblibzfsp,
++			       TALLOC_CTX *mem_ctx,
++			       const char *dataset_name,
++			       char **dataset_mp_out);
++/*
++ * Get userspace quotas for a given path, ID, and quota type.
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	path		 	the full path in which to get quota.
++ * @param[in]	xid		 	user id or group id.
++ * @param[in]	quota_type	 	quota type
++ * @param[out]	hardlimit	 	quota size in bytes
++ * @param[out]	usedspace		space used against quota in bytes
++ * 
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_get_userspace_quota(struct smblibzfshandle *smblibzfsp,
++				char *path,
++				int64_t xid,
++				int quota_type,
++				uint64_t *hardlimit,
 +				uint64_t *usedspace);
 +
-+int smb_zfs_set_userspace_quota(struct smblibzfshandle *smblibzfsp, char *path,
-+				int64_t xid, int quota_type, uint64_t hardlimit);
++/*
++ * Set userspace quotas for a given path, ID, and quota type. May require
++ * fail with EPERM if user lacks permissions to set quota.
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	path		 	the full path in which to get quota.
++ * @param[in]	xid		 	user id or group id.
++ * @param[in]	quota_type	 	quota type
++ * @param[in]	hardlimit	 	quota size in bytes
++ * 
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_set_userspace_quota(struct smblibzfshandle *smblibzfsp,
++				char *path,
++				int64_t xid,
++				int quota_type,
++				uint64_t hardlimit);
 +
-+uint64_t smb_zfs_disk_free(struct smblibzfshandle *smblibzfsp, char *path,
-+			   uint64_t *bsize, uint64_t *dfree, uint64_t *dsize, uid_t euid);
++uint64_t smb_zfs_disk_free(struct smblibzfshandle *smblibzfsp,
++			   char *path,
++			   uint64_t *bsize,
++			   uint64_t *dfree,
++			   uint64_t *dsize,
++			   uid_t euid);
 +
-+int smb_zfs_create_child_dataset(struct smblibzfshandle *smblibzfsp, char *parent,
-+				 const char *new, const char *quota);
++/*
++ * This function creates a child dataset of a specified parent dataset.
++ * Realpath of parent dataset should be passed into the function. Name
++ * of child dataset is expected to be relative to parent dataset. For example, 
++ * if parent datset is tank/share and you wish to create tank/share/sub1
++ * then the expected name of the child dataset is "sub1". Aclmode
++ * will be inherited from parent.
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @para[in]	parent			real path to parent dataset
++ * @param[in]	base			name of child dataset.
++ * @param[in]	quota			ZFS dataset quota
++ *
++ * @return	0 on success -1 on failure.
++ */
++int smb_zfs_create_child_dataset(struct smblibzfshandle *smblibzfsp,
++				 char *parent,
++				 const char *new,
++				 const char *quota);
 +
-+int smb_zfs_get_case_sensitivity(struct smblibzfshandle *smblibzfsp, char* path);
++/*
++ * Retrieve the value of a user-defined ZFS dataset property
++ * "org.samba:" prefix will be automatically applied.
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	mem_ctx			talloc memory context
++ * @param[in]	path			path on which to retrieve
++ *					custom user property
++ * @param[in]	prop			property name
++ * @param[out]	value			talloc'ed string containing 
++ *					value of propert.
++ *
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_get_user_prop(struct smblibzfshandle *smblibzfsp,
++			  TALLOC_CTX *mem_ctx,
++			  const char *path,
++			  const char *prop,
++			  char **value);
 +
++/*
++ * Set the value of a user-defined ZFS dataset property.
++ * "org.samba:" prefix will be automatically applied.
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	path			path on which to set 
++ *					custom user property
++ * @param[in]	prop			property name
++ * @param[out]	value			value to set 
++ *
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_set_user_prop(struct smblibzfshandle *smblibzfsp,
++			  const char *path,
++			  const char *prop,
++			  const char *value);
++
++
++/*
++ * Get the ZFS dataset properties for a given path
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	path			path for which to get properties 
++ * @param[in]	pprops			struct zfs_dataset_prop
++ *
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_path_get_props(struct smblibzfshandle *smblibzfsp,
++			   const char *path,
++			   struct zfs_dataset_prop **pprop);
++
++/*
++ * This function returns a list of ZFS snapshots matching the specified
++ * filters.
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	mem_ctx			talloc memory context
++ * @param[in]	ignore_empty_snaps	ignore snapshots with zero space used
++ * @param[in]	inclusions		list of filters to determine whether to
++ *					include a snapshot
++ * @param[in]	exclusions		list of filters to determine whether to
++ *					exclude a snapshot
++ * @param[in]	start			snapshots with create time greater than
++ *					this will be included
++ * @param[in]	end			snapshots with create time less than
++ *					this will be included
++ *
++ * @return	struct snapshot_list
++ */
 +struct snapshot_list *smb_zfs_list_snapshots(struct smblibzfshandle *smblibzfsp,
-+    TALLOC_CTX *mem_ctx, const char *fs, bool ignore_empty_snaps, const char **inclusions, const char **exclusions);
++					     TALLOC_CTX *mem_ctx,
++					     const char *fs,
++					     bool ignore_empty_snaps,
++					     const char **inclusions,
++					     const char **exclusions,
++					     time_t start,
++					     time_t end);
++
++/*
++ * Delete a list of ZFS snapshots. List is converted into an nvlist
++ * and deletion performed in single ZFS ioctl. Required parts of
++ * snapshot list are snaps->dataset_name, and entry->name for entries.
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	mem_ctx			talloc memory context
++ * @param[in]	snaps			list of snapshots to delete
++ *
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_delete_snapshots(struct smblibzfshandle *smblibzfsp,
++			     TALLOC_CTX *mem_ctx,
++			     struct snapshot_list *snaps);
++
++/*
++ * Take a named snapshot of a given path.
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	path			path on which to take snapshot
++ * @param[in]	snapshot_name		name to give snapshot 
++ *
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_snapshot(struct smblibzfshandle *smblibzfsp,
++		     const char *path,
++		     const char *snapshot_name,
++		     bool recursive);
++
++/*
++ * Roll back to named snapshot. This is a destructive process.
++ * Given a path, convert path to dataset handle and rollback to a specific
++ * snapshot, discarding any data changes since then and making it the
++ * active dataset.
++ *
++ * Any snapshots and bookmarks more recent than the target are
++ * destroyed, along with their dependents (i.e. clones).
++ *
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	path			path on which to take snapshot
++ * @param[in]	snapshot_name		name to give snapshot 
++ * @param[in]	force			forcibly unmount cloned filesystems
++ *
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_rollback(struct smblibzfshandle *smblibzfsp,
++		     const char *path,
++		     const char *snapshot_name,
++		     bool force);
++
++/*
++ * Roll back to the last successful snapshot. This is a destructive process. All
++ * data from after the last snapshot was taken will be destroyed. 
++ * @param[in]	smblibzfsp		smblibzfs handle struct
++ * @param[in]	path			path on which to take snapshot
++ * @param[in]	snapshot_name		name to give snapshot 
++ *
++ * @return	0 on success -1 on failure
++ */
++int smb_zfs_rollback_last(struct smblibzfshandle *smblibzfsp, const char *path);
 +
 +#endif	/* !__SMB_LIBZFS_H */
 diff --git a/source3/modules/vfs_default.c b/source3/modules/vfs_default.c
@@ -855,10 +1327,10 @@ index 5095f65..1b55e64 100644
  static int vfswrap_get_shadow_copy_data(struct vfs_handle_struct *handle,
 diff --git a/source3/modules/vfs_ixnas.c b/source3/modules/vfs_ixnas.c
 new file mode 100644
-index 0000000..dec41de
+index 0000000..f6ea466
 --- /dev/null
 +++ b/source3/modules/vfs_ixnas.c
-@@ -0,0 +1,2284 @@
+@@ -0,0 +1,2286 @@
 +/*
 + *  Unix SMB/CIFS implementation.
 + *  A dumping ground for FreeBSD-specific VFS functions. For testing case
@@ -920,7 +1392,7 @@ index 0000000..dec41de
 +	bool zfs_space_enabled;
 +	bool zfs_quota_enabled;
 +	bool zfs_auto_homedir;
-+	bool dataset_is_casesensitive;
++	struct zfs_dataset_prop *props;
 +	const char *homedir_quota;
 +	uint64_t base_user_quota; 
 +};
@@ -2838,7 +3310,7 @@ index 0000000..dec41de
 +				struct ixnas_config_data,
 +				return -1);
 +
-+	if (config->dataset_is_casesensitive) {
++	if (config->props->casesens != SMBZFS_INSENSITIVE) {
 +		return SMB_VFS_NEXT_RENAME(handle,
 +					   smb_fname_src,
 +					   smb_fname_dst);
@@ -2933,8 +3405,9 @@ index 0000000..dec41de
 +		DEBUG(0, ("talloc_zero() failed\n"));
 +		errno = ENOMEM;
 +		return -1;
-+	}	
-+	config->dataset_is_casesensitive = True;
++	}
++
++	config->props = talloc_zero(handle->conn, struct zfs_dataset_prop);
 +
 +#if HAVE_LIBZFS
 +	ret = get_smblibzfs_handle(handle->conn, &libzp);
@@ -2946,10 +3419,12 @@ index 0000000..dec41de
 +	config->libzp = libzp;
 +
 +	/* Parameters for homedirs and quotas */
-+	consens = smb_zfs_get_case_sensitivity(config->libzp, handle->conn->connectpath);
-+	if (consens == SMBZFS_INSENSITIVE) {
-+		DBG_ERR("setting case sensitivity to insensitive\n");
-+		config->dataset_is_casesensitive = False;
++	ret = smb_zfs_path_get_props(config->libzp,
++				     handle->conn->connectpath,
++				     &config->props);
++	if (ret == -1) {
++		DBG_ERR("Failed to get ZFS properties for share\n");
++		return -1;
 +	}
 +
 +	config->zfs_auto_homedir = lp_parm_bool(SNUM(handle->conn), 
@@ -2973,8 +3448,7 @@ index 0000000..dec41de
 +	if (config->base_user_quota) {
 +		set_base_user_quota(handle, config, user);
 +	}
-+
-+	if (!config->dataset_is_casesensitive) {
++	if (config->props->casesens == SMBZFS_INSENSITIVE) {
 +		DBG_INFO("ixnas: case insensitive dataset detected, "
 +			 "automatically adjusting case sensitivity settings.\n");
 +		lp_do_parameter(SNUM(handle->conn),

--- a/net/samba410/files/0001-add-shadow_copy_zfs.patch
+++ b/net/samba410/files/0001-add-shadow_copy_zfs.patch
@@ -24,10 +24,10 @@ index 4331c2f..a9de97f 100644
  
 diff --git a/source3/modules/vfs_shadow_copy_zfs.c b/source3/modules/vfs_shadow_copy_zfs.c
 new file mode 100644
-index 0000000..496ab46
+index 0000000..1bace80
 --- /dev/null
 +++ b/source3/modules/vfs_shadow_copy_zfs.c
-@@ -0,0 +1,1990 @@
+@@ -0,0 +1,1919 @@
 +/* shadow_copy_zfs: a shadow copy module for ZFS
 + *
 + * Copyright (C) Andrew Tridgell   2007 (portions taken from shadow_copy_zfs)
@@ -103,7 +103,6 @@ index 0000000..496ab46
 +
 +	/* Snapshot parameters */
 +	bool 			ignore_empty_snaps;	
-+	const char 		*sort_order;
 +	const char 		*dataset_path;
 +	const char 		**inclusions;
 +	const char 		**exclusions;
@@ -194,7 +193,7 @@ index 0000000..496ab46
 +						   path,
 +						   config->ignore_empty_snaps,
 +						   config->inclusions,
-+						   config->exclusions);
++						   config->exclusions, 0, 0);
 +		if (snapshots != NULL) {
 +			if (config->snapshots != NULL) {
 +				TALLOC_FREE(config->snapshots);
@@ -386,47 +385,6 @@ index 0000000..496ab46
 +	pcopy[GMT_NAME_LEN] = '/';
 +
 +	return pcopy;
-+}
-+
-+static int shadow_copy_zfs_label_cmp_asc(const void *x, const void *y)
-+{
-+	return strncmp((*((struct snapshot_entry **) x))->label,
-+		       (*((struct snapshot_entry **) y))->label,
-+		       sizeof(SHADOW_COPY_LABEL));
-+}
-+
-+static int shadow_copy_zfs_label_cmp_desc(const void *x, const void *y)
-+{
-+	return -strncmp((*((struct snapshot_entry **) x))->label,
-+			(*((struct snapshot_entry **) y))->label,
-+			sizeof(SHADOW_COPY_LABEL));
-+}
-+
-+/*
-+  sort the shadow copy data in ascending or descending order
-+ */
-+static void shadow_copy_zfs_sort_data(vfs_handle_struct *handle,
-+    struct snapshot_list *snapshots)
-+{
-+	const char *sort;
-+
-+	if (snapshots->num_entries <= 0) {
-+		return;
-+	}
-+
-+	sort = lp_parm_const_string(SNUM(handle->conn), "shadow",
-+				    "sort", SHADOW_COPY_ZFS_DEFAULT_SORT);
-+
-+	if (strcmp(sort, "asc") == 0) {
-+		snapshots->cmpfunc = shadow_copy_zfs_label_cmp_asc;
-+	} else {
-+		snapshots->cmpfunc = shadow_copy_zfs_label_cmp_desc;
-+	}
-+
-+	TYPESAFE_QSORT(snapshots->entries, snapshots->num_entries,
-+		       snapshots->cmpfunc);
-+
-+	return;
 +}
 +
 +static void shadow_copy_zfs_free_snapshots(void **datap)
@@ -622,8 +580,6 @@ index 0000000..496ab46
 +		fds_len = strlen(snapshots->dataset_name) - strlen(config->dataset_path);
 +	}
 +
-+	shadow_copy_zfs_sort_data(handle, snapshots);
-+
 +	/* get the mountpoint */
 +	mountpoint = snapshots->mountpoint;
 +	mplen = strlen(mountpoint);
@@ -659,13 +615,9 @@ index 0000000..496ab46
 +		}
 +	}
 +	/* get snapshot name */
-+	strlcpy(entry->label, fname, GMT_NAME_LEN+1);
-+	snapshot = bsearch(&entry, snapshots->entries, snapshots->num_entries,
-+			   sizeof(snapshots->entries[0]), snapshots->cmpfunc);
-+	for (idx = 0; idx < snapshots->num_entries; idx++) {
-+		if (strncmp(fname, snapshots->entries[idx]->label, GMT_NAME_LEN)
-+		    == 0) {
-+			snapshot = snapshots->entries[idx]->name;
++	for (entry = snapshots->entries; entry; entry = entry->next) {
++		if (strncmp(fname, entry->label, GMT_NAME_LEN) == 0) {
++			snapshot = entry->name;
 +			break;
 +		}
 +	}
@@ -1293,7 +1245,8 @@ index 0000000..496ab46
 +	TALLOC_CTX *tmp_ctx = NULL;
 +	struct shadow_copy_zfs_config *config = NULL;
 +	struct snapshot_list *snapshots = NULL;
-+	unsigned idx;
++	struct snapshot_entry *entry = NULL;
++	uint idx = 0;
 +	char tmpbuf[PATH_MAX];
 +	char *fullpath, *to_free;
 +	ssize_t len;
@@ -1312,13 +1265,12 @@ index 0000000..496ab46
 +	    return -1);
 +
 +	tmp_ctx = talloc_new(config);
-+
 +	snapshots = smb_zfs_list_snapshots(config->libzp,
 +					   tmp_ctx,
 +					   fullpath,
 +					   config->ignore_empty_snaps,
 +					   config->inclusions,
-+					   config->exclusions);
++					   config->exclusions, 0, 0);
 +
 +	if (snapshots == NULL) {
 +		DBG_INFO("failed to retrieve snapshots for %s\n", fullpath);
@@ -1326,7 +1278,6 @@ index 0000000..496ab46
 +		TALLOC_FREE(to_free);
 +		return -1;
 +	}
-+	shadow_copy_zfs_sort_data(handle, snapshots);
 +	shadow_copy_zfs_data->num_volumes = snapshots->num_entries;
 +	shadow_copy_zfs_data->labels = NULL;
 +
@@ -1343,13 +1294,12 @@ index 0000000..496ab46
 +			return -1;
 +		}
 +
-+		for (idx = 0; idx < snapshots->num_entries; idx++) {
++		for (entry = snapshots->entries; entry; entry = entry->next) {
 +			strlcpy(shadow_copy_zfs_data->labels[idx],
-+				snapshots->entries[idx]->label,
-+				sizeof(shadow_copy_zfs_data->labels[0]));
-+		}
++				entry->label, sizeof(entry->label));
++			idx++;
++        	}
 +	}
-+
 +	TALLOC_FREE(to_free);
 +	TALLOC_FREE(tmp_ctx);
 +	return 0;
@@ -1877,7 +1827,6 @@ index 0000000..496ab46
 +	struct smblibzfshandle	*libzp;
 +	struct shadow_copy_zfs_config *config = NULL;
 +	int ret, enumval;
-+	const char *sort_order;
 +	const char *backend_str = NULL;
 +	const char *tmp_ds = NULL;
 +
@@ -1936,16 +1885,6 @@ index 0000000..496ab46
 +
 +	DBG_INFO("Dataset_Path is %s\n", config->dataset_path);
 +
-+	sort_order = lp_parm_const_string(SNUM(handle->conn),
-+					  "shadow", "sort", "desc");
-+
-+	config->sort_order = talloc_strdup(config, sort_order);
-+	if (config->sort_order == NULL) {
-+		DEBUG(0, ("talloc_strdup() failed\n"));
-+		errno = ENOMEM;
-+		return -1;
-+	}
-+
 +	config->inclusions = lp_parm_string_list(SNUM(handle->conn), "shadow",
 +						"include", empty_list);
 +	config->exclusions = lp_parm_string_list(SNUM(handle->conn), "shadow",
@@ -1959,16 +1898,6 @@ index 0000000..496ab46
 +
 +	config->timedelta = lp_parm_int(SNUM(handle->conn),
 +					"shadow", "snap_timedelta", 300);
-+
-+	DBG_DEBUG("shadow_copy_zfs_connect: configuration:\n"
-+		   "  share root: '%s'\n"
-+		   "  dataset path: '%s'\n"
-+		   "  sort order: %s\n"
-+		   "",
-+		   handle->conn->connectpath,
-+		   config->dataset_path,
-+		   config->sort_order
-+		   );
 +
 +
 +	SMB_VFS_HANDLE_SET_DATA(handle, config,

--- a/net/samba410/files/patch-source3__modules__wscript_build
+++ b/net/samba410/files/patch-source3__modules__wscript_build
@@ -59,7 +59,7 @@
 +                       '%%SRC_BASE%%/sys/cddl/contrib/opensolaris/uts/common/sys',
 +                       '%%SRC_BASE%%/sys/cddl/contrib/opensolaris/common/zfs',
 +                   ],
-+                   ldflags='-lgeom -luutil -lzfs_core -lzfs',
++                   ldflags='-lgeom -luutil -lzfs_core -lzfs -lnvpair',
 +                   enabled=bld.SAMBA3_IS_ENABLED_MODULE('vfs_ixnas'),
 +                   private_library=True)
 +


### PR DESCRIPTION
Simplify snapshot related code in smblibzfs. Convert to using
linked list of snapshots. Reduce instances of iterating through
snapshot lists in shadow_copy_zfs. Lay groundwork for future
VFS modules that interact with libzfs. Add ability to specify
start and end times for snapshot queries.