### PR TITLE
NAS-104559 / 11.3 / Add devel/rcs57 as a dependency for iocage

### DIFF
--- a/sysutils/iocage/Makefile
+++ b/sysutils/iocage/Makefile
@@ -24,7 +24,8 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}click>=6.7:devel/py-click@${PY_FLAVOR} \
 	${PYTHON_PKGNAMEPREFIX}requests>=2.11.1:www/py-requests@${PY_FLAVOR} \
 	${PYTHON_PKGNAMEPREFIX}libzfs>=1.0:devel/py-libzfs@${PY_FLAVOR} \
 	${PYTHON_PKGNAMEPREFIX}GitPython>=2.1.10:devel/py-gitpython@${PY_FLAVOR} \
-	${PYTHON_PKGNAMEPREFIX}netifaces>=0.10.6:net/py-netifaces@${PY_FLAVOR}
+	${PYTHON_PKGNAMEPREFIX}netifaces>=0.10.6:net/py-netifaces@${PY_FLAVOR} \
+	merge:devel/rcs57
 
 CONFLICTS=  py-iocage-[0-9]* iocage-[0-9]* iocage-devel-[0-9]*
 


### PR DESCRIPTION
This commit adds rcs57 as a dependency for iocage as merge(1) is required for jail upgrades. ( https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=240177 )