### PR TITLE
Patch libvirt to use 31st slot for lpc 

### DIFF
--- a/devel/libvirt/Makefile
+++ b/devel/libvirt/Makefile
@@ -3,6 +3,7 @@
 
 PORTNAME=	libvirt
 PORTVERSION=	6.2.0
+PORTREVISION=	1
 CATEGORIES=	devel
 MASTER_SITES=	http://libvirt.org/sources/ \
 		ftp://libvirt.org/libvirt/

--- a/devel/libvirt/files/patch-src_bhyve_bhyve__command.c
+++ b/devel/libvirt/files/patch-src_bhyve_bhyve__command.c
@@ -1,6 +1,6 @@
---- src/bhyve/bhyve_command.c.orig	2019-04-27 10:31:34 UTC
+--- src/bhyve/bhyve_command.c.orig	2020-04-14 22:48:12 UTC
 +++ src/bhyve/bhyve_command.c
-@@ -228,6 +228,12 @@ bhyveBuildAHCIControllerArgStr(const virDomainDef *def
+@@ -220,13 +220,20 @@ bhyveBuildAHCIControllerArgStr(const virDomainDef *def
                             _("unsupported disk device"));
              goto error;
          }
@@ -13,29 +13,27 @@
          virBufferAddBuffer(&buf, &device);
          virBufferFreeAndReset(&device);
      }
-@@ -236,8 +242,9 @@ bhyveBuildAHCIControllerArgStr(const virDomainDef *def
-         goto error;
-
+ 
      virCommandAddArg(cmd, "-s");
 -    virCommandAddArgFormat(cmd, "%d:0,ahci%s",
 +    virCommandAddArgFormat(cmd, "%d:%d,ahci%s",
                             controller->info.addr.pci.slot,
 +                           controller->info.addr.pci.function,
                             virBufferCurrentContent(&buf));
-
+ 
      ret = 0;
-@@ -291,6 +298,7 @@ bhyveBuildVirtIODiskArgStr(const virDomainDef *def ATT
-                      virCommandPtr cmd)
+@@ -280,6 +287,7 @@ bhyveBuildVirtIODiskArgStr(const virDomainDef *def G_G
+                            virCommandPtr cmd)
  {
      const char *disk_source;
 +    virBuffer opt = VIR_BUFFER_INITIALIZER;
-
+ 
      if (virDomainDiskTranslateSourcePool(disk) < 0)
          return -1;
-@@ -310,10 +318,17 @@ bhyveBuildVirtIODiskArgStr(const virDomainDef *def ATT
-
+@@ -299,10 +307,17 @@ bhyveBuildVirtIODiskArgStr(const virDomainDef *def G_G
+ 
      disk_source = virDomainDiskGetSource(disk);
-
+ 
 +    virBufferAsprintf(&opt, "%d:%d,virtio-blk,%s", disk->info.addr.pci.slot, disk->info.addr.pci.function, disk_source);
 +
 +    if (disk->blockio.logical_block_size) {
@@ -43,20 +41,29 @@
 +        if (disk->blockio.physical_block_size) {
 +            virBufferAsprintf(&opt, "/%d", disk->blockio.physical_block_size);
 +        }
-+     }
++    }
 +
      virCommandAddArg(cmd, "-s");
 -    virCommandAddArgFormat(cmd, "%d:0,virtio-blk,%s",
 -                           disk->info.addr.pci.slot,
 -                           disk_source);
 +    virCommandAddArgBuffer(cmd, &opt);
-
+ 
      return 0;
  }
-@@ -383,17 +398,6 @@ bhyveBuildGraphicsArgStr(const virDomainDef *def,
+@@ -366,7 +381,7 @@ static int
+ bhyveBuildLPCArgStr(const virDomainDef *def G_GNUC_UNUSED,
+                     virCommandPtr cmd)
+ {
+-    virCommandAddArgList(cmd, "-s", "1,lpc", NULL);
++    virCommandAddArgList(cmd, "-s", "31,lpc", NULL);
+     return 0;
+ }
+ 
+@@ -425,17 +440,6 @@ bhyveBuildGraphicsArgStr(const virDomainDef *def,
              goto error;
          }
-
+ 
 -        if (graphics->data.vnc.auth.passwd) {
 -            virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
 -                           _("vnc password auth not supported"));
@@ -71,9 +78,9 @@
          if (glisten->address) {
              escapeAddr = strchr(glisten->address, ':') != NULL;
              if (escapeAddr)
-@@ -415,6 +419,9 @@ bhyveBuildGraphicsArgStr(const virDomainDef *def,
+@@ -457,6 +461,9 @@ bhyveBuildGraphicsArgStr(const virDomainDef *def,
          }
-
+ 
          virBufferAsprintf(&opt, ":%d", graphics->data.vnc.port);
 +        if (graphics->data.vnc.auth.passwd) {
 +            virBufferAsprintf(&opt, ",password=%s", graphics->data.vnc.auth.passwd);
@@ -81,3 +88,11 @@
          break;
      case VIR_DOMAIN_GRAPHICS_LISTEN_TYPE_SOCKET:
      case VIR_DOMAIN_GRAPHICS_LISTEN_TYPE_NONE:
+@@ -582,7 +589,6 @@ virBhyveProcessBuildBhyveCmd(bhyveConnPtr driver, virD
+      * since it forces the guest to exit when it spins on a lock acquisition.
+      */
+     virCommandAddArg(cmd, "-H"); /* vmexit from guest on hlt */
+-    virCommandAddArg(cmd, "-P"); /* vmexit from guest on pause */
+ 
+     virCommandAddArgList(cmd, "-s", "0:0,hostbridge", NULL);
+ 


### PR DESCRIPTION
Windows vm's only like to use 0/31 slots for lpc and otherwise they don't work as desired wrt keyboard. -P flag has been removed as well to keep consistent with 11.3 behaviour.