### PR TITLE
NAS-105890 / 12.0 / Use SIGTERM after destroying VM for force-poweroff

### DIFF
--- a/devel/libvirt/Makefile
+++ b/devel/libvirt/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	libvirt
 PORTVERSION=	6.2.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	devel
 MASTER_SITES=	http://libvirt.org/sources/ \
 		ftp://libvirt.org/libvirt/

--- a/devel/libvirt/files/patch-src_bhyve_bhyve__process.c
+++ b/devel/libvirt/files/patch-src_bhyve_bhyve__process.c
@@ -1,0 +1,11 @@
+--- src/bhyve/bhyve_process.c.orig	2020-04-24 15:37:02 UTC
++++ src/bhyve/bhyve_process.c
+@@ -298,6 +298,8 @@ virBhyveProcessStop(bhyveConnPtr driver,
+     if (virCommandRun(cmd, NULL) < 0)
+         goto cleanup;
+ 
++    ignore_value(virProcessKill(vm->pid, SIGTERM));
++
+     if ((priv != NULL) && (priv->mon != NULL))
+          bhyveMonitorClose(priv->mon);
+ 


### PR DESCRIPTION
This commit introduces changes where we send a SIGTERM to vm pid if we are doing a poweroff for the VM. This is only desired if the VM in question is configured with VNC server set to delay until the user initiates a connection. In this case the bhyve process does not die as vncserver is waiting for a connection to be initiated. Sending a SIGTERM after this makes sure that the bhyve process exits and we do a proper cleanup.