### PR TITLE
NAS-106390 / 11.3 / Samba:nsswitch:pam_winbind - make openpam happy with error codes

### DIFF
--- a/net/samba410/Makefile
+++ b/net/samba410/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}410
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			0
+PORTREVISION=			1
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -33,6 +33,7 @@ EXTRA_PATCHES+=			${PATCHDIR}/wscript_changes.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/experimental_aio.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/ix-smbtorture.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/debug.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/pam_winbind_openpam.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba410/files/pam_winbind_openpam.patch
+++ b/net/samba410/files/pam_winbind_openpam.patch
@@ -1,0 +1,117 @@
+diff --git a/nsswitch/pam_winbind.c b/nsswitch/pam_winbind.c
+index 0ba1955f007..042098796c4 100644
+--- a/nsswitch/pam_winbind.c
++++ b/nsswitch/pam_winbind.c
+@@ -2639,6 +2639,67 @@ out:
+ 	return retval;
+ }
+ 
++#ifdef HAVE_SECURITY_PAM_APPL_H
++static int openpam_convert_error_code(struct pwb_context *ctx,
++				      enum pam_winbind_request_type req,
++				      int r)
++{
++	if (r == PAM_SUCCESS ||
++	    r == PAM_SYSTEM_ERR ||
++	    r == PAM_SERVICE_ERR ||
++	    r == PAM_BUF_ERR ||
++	    r == PAM_CONV_ERR ||
++	    r == PAM_PERM_DENIED ||
++	    r == PAM_ABORT)
++		return r;
++
++	/* specific winbind request types */
++	switch (req) {
++	case PAM_WINBIND_AUTHENTICATE:
++		if (r == PAM_AUTH_ERR ||
++		    r == PAM_CRED_INSUFFICIENT ||
++		    r == PAM_AUTHINFO_UNAVAIL ||
++		    r == PAM_USER_UNKNOWN ||
++		    r == PAM_MAXTRIES)
++			return r;
++		break;
++	case PAM_WINBIND_SETCRED:
++		if (r == PAM_CRED_UNAVAIL ||
++		    r == PAM_CRED_EXPIRED ||
++		    r == PAM_USER_UNKNOWN ||
++		    r == PAM_CRED_ERR)
++			return r;
++		break;
++	case PAM_WINBIND_ACCT_MGMT:
++		if (r == PAM_USER_UNKNOWN ||
++		    r == PAM_AUTH_ERR ||
++		    r == PAM_NEW_AUTHTOK_REQD ||
++		    r == PAM_ACCT_EXPIRED)
++			return r;
++		break;
++	case PAM_WINBIND_OPEN_SESSION:
++	case PAM_WINBIND_CLOSE_SESSION:
++		if (r == PAM_SESSION_ERR)
++			return r;
++		break;
++	case PAM_WINBIND_CHAUTHTOK:
++		if (r == PAM_PERM_DENIED ||
++		    r == PAM_AUTHTOK_ERR ||
++		    r == PAM_AUTHTOK_RECOVERY_ERR ||
++		    r == PAM_AUTHTOK_LOCK_BUSY ||
++		    r == PAM_AUTHTOK_DISABLE_AGING ||
++		    r == PAM_TRY_AGAIN)
++			    return r;
++		    break;
++	}
++	_pam_log(ctx, LOG_INFO,
++		 "Converting PAM error [%d] to PAM_SERVICE_ERR.\n", r);
++	return PAM_SERVICE_ERR;
++};
++#else
++#define openpam_convert_error_code(a, b, c) (c)
++#endif
++
+ PAM_EXTERN
+ int pam_sm_authenticate(pam_handle_t *pamh, int flags,
+ 			int argc, const char **argv)
+@@ -2843,7 +2904,7 @@ int pam_sm_setcred(pam_handle_t *pamh, int flags,
+ 
+ 	TALLOC_FREE(ctx);
+ 
+-	return ret;
++	return openpam_convert_error_code(ctx, PAM_WINBIND_SETCRED, ret);
+ }
+ 
+ /*
+@@ -2946,7 +3007,7 @@ int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags,
+ 
+ 	TALLOC_FREE(ctx);
+ 
+-	return ret;
++	return openpam_convert_error_code(ctx, PAM_WINBIND_ACCT_MGMT, ret);
+ }
+ 
+ PAM_EXTERN
+@@ -2973,7 +3034,7 @@ int pam_sm_open_session(pam_handle_t *pamh, int flags,
+ 
+ 	TALLOC_FREE(ctx);
+ 
+-	return ret;
++	return openpam_convert_error_code(ctx, PAM_WINBIND_OPEN_SESSION, ret);
+ }
+ 
+ PAM_EXTERN
+@@ -2995,7 +3056,7 @@ int pam_sm_close_session(pam_handle_t *pamh, int flags,
+ 
+ 	TALLOC_FREE(ctx);
+ 
+-	return ret;
++	return openpam_convert_error_code(ctx, PAM_WINBIND_CLOSE_SESSION, ret);
+ }
+ 
+ /**
+@@ -3347,7 +3408,7 @@ out:
+ 
+ 	TALLOC_FREE(ctx);
+ 
+-	return ret;
++	return openpam_convert_error_code(ctx, PAM_WINBIND_CHAUTHTOK, ret);
+ }
+ 
+ #ifdef PAM_STATIC


### PR DESCRIPTION
In some cases pam_winbind will return PAM_AUTHINFO_UNAVAIL. This
may be due to translation of WBERR into a PAM error. OpenPAM logs
error messages if the return is unexpected. Convert the error messages
in this case to PAM_SERVICE_ERR and log the operation in the pam_winbind
log, which is user-configurable.