### PR TITLE
NAS-106629 / 11.3 / Samba:s3:winbindd:idmap_ad fix null pointer dereference

### DIFF
--- a/net/samba410/Makefile
+++ b/net/samba410/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}410
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			1
+PORTREVISION=			2
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -34,6 +34,7 @@ EXTRA_PATCHES+=			${PATCHDIR}/experimental_aio.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/ix-smbtorture.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/debug.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/pam_winbind_openpam.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/fix-idmap_ad.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba410/files/fix-idmap_ad.patch
+++ b/net/samba410/files/fix-idmap_ad.patch
@@ -1,0 +1,32 @@
+diff --git a/source3/winbindd/idmap_ad.c b/source3/winbindd/idmap_ad.c
+index a93c61f54d1..cf2416495cb 100644
+--- a/source3/winbindd/idmap_ad.c
++++ b/source3/winbindd/idmap_ad.c
+@@ -162,6 +162,13 @@ static TLDAPRC get_attrnames_by_oids(struct tldap_context *ld,
+ 	}
+ 
+ 	TALLOC_FREE(msgs);
++	for (i=0; i<num_oids; i++) {
++		if (names[i] == NULL) {
++			DBG_ERR("Failed to retrieve schema name for "
++				"oid [%s]\n", oids[i]);
++			return TLDAP_FILTER_ERROR;
++		}
++	}
+ 
+ 	return TLDAP_SUCCESS;
+ }
+@@ -228,6 +235,13 @@ static TLDAPRC get_posix_schema_names(struct tldap_context *ld,
+ 	}
+ 
+ 	rc = get_attrnames_by_oids(ld, schema, schema_path, 6, oids, names);
++	if (TLDAP_RC_EQUAL(rc, TLDAP_FILTER_ERROR)) {
++		DBG_ERR("Failed to retrieve schema names for [%s] "
++			"switching to rfc2307.\n", schema_mode);
++		oids = oids_rfc2307;
++		rc = get_attrnames_by_oids(ld, schema, schema_path,
++					   6, oids, names);
++	}
+ 	TALLOC_FREE(schema_path);
+ 	if (!TLDAP_RC_IS_SUCCESS(rc)) {
+ 		TALLOC_FREE(schema);


### PR DESCRIPTION
If idmap ad has incorrect schema type selected, user authentication
attempt can cause null pointer dereference. On failure to detect
names for schema OIDs, fall back to rfc2307 schema from SFU/SFU20.