### PR TITLE
NAS-106702 / 12.1 / Samba:s3:smbd:dosmode - allow sparse flag to be set through vfs

### DIFF
--- a/net/samba/Makefile
+++ b/net/samba/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			7
+PORTREVISION=			8
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -36,6 +36,7 @@ EXTRA_PATCHES+=			${PATCHDIR}/debug.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/tevent_kqueue.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/silence-openpam-warnings.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/fix-idmap_ad.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/allow_vfs_set_sparse.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba/files/allow_vfs_set_sparse.patch
+++ b/net/samba/files/allow_vfs_set_sparse.patch
@@ -1,0 +1,15 @@
+diff --git a/source3/smbd/dosmode.c b/source3/smbd/dosmode.c
+index 322bf4476d6..0d249497a70 100644
+--- a/source3/smbd/dosmode.c
++++ b/source3/smbd/dosmode.c
+@@ -1168,10 +1168,6 @@ NTSTATUS file_set_sparse(connection_struct *conn,
+ 	DEBUG(10,("file_set_sparse: setting sparse bit %u on file %s\n",
+ 		  sparse, smb_fname_str_dbg(fsp->fsp_name)));
+ 
+-	if (!lp_store_dos_attributes(SNUM(conn))) {
+-		return NT_STATUS_INVALID_DEVICE_REQUEST;
+-	}
+-
+ 	status = vfs_stat_fsp(fsp);
+ 	if (!NT_STATUS_IS_OK(status)) {
+ 		return status;


### PR DESCRIPTION
Current behavior with dosmode xattrs prevents setting sparse flag
unless DOS attribute xattrs are enabled. This should also be passed
through the VFS.