### PR TITLE
NAS-106661 / 12.0 / Samba s3:locking:share_mode_lock - fix crash in freeing shared mode lock

### DIFF
--- a/net/samba/Makefile
+++ b/net/samba/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			0
+PORTREVISION=			1
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -37,6 +37,7 @@ EXTRA_PATCHES+=			${PATCHDIR}/tevent_kqueue.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/silence-openpam-warnings.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/fix-idmap_ad.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/allow_vfs_set_sparse.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/fix-fruit-locking.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba/files/fix-fruit-locking.patch
+++ b/net/samba/files/fix-fruit-locking.patch
@@ -1,0 +1,79 @@
+From 821699d4d82c261a96ea7d73e9a7d0e42612bd9c Mon Sep 17 00:00:00 2001
+From: Andrew Walker <awalker@ixsystems.com>
+Date: Thu, 2 Jul 2020 12:05:49 -0700
+Subject: [PATCH] Fix crash in parsing shared mode lock
+
+Retrieve share mode data from static_share_mode_record_value when
+share_mode_do_locked_fn() is called from dbwrap_watched_do_locked_fn().
+---
+ source3/locking/share_mode_lock.c | 48 ++++++++++++++++++++++++++++---
+ 1 file changed, 44 insertions(+), 4 deletions(-)
+
+diff --git a/source3/locking/share_mode_lock.c b/source3/locking/share_mode_lock.c
+index a736bc24469..96400341b7b 100644
+--- a/source3/locking/share_mode_lock.c
++++ b/source3/locking/share_mode_lock.c
+@@ -589,6 +589,28 @@ static NTSTATUS get_static_share_mode_data(
+ 	return NT_STATUS_OK;
+ }
+ 
++static NTSTATUS get_static_share_mode_value_data(
++	TDB_DATA value,
++	struct file_id id)
++{
++	struct share_mode_data *d = NULL;
++	TDB_DATA key;
++
++	if (value.dptr == NULL) {
++		return NT_STATUS_NOT_FOUND;
++	}
++	key = locking_key(&id);
++	d = parse_share_modes(lock_db, key, value);
++	if (d == NULL) {
++		return NT_STATUS_INTERNAL_DB_CORRUPTION;
++	}
++
++	d->id = id;
++
++	static_share_mode_data = d;
++
++	return NT_STATUS_OK;
++}
+ /*******************************************************************
+  Get a share_mode_lock, Reference counted to allow nested calls.
+ ********************************************************************/
+@@ -654,10 +676,28 @@ struct share_mode_lock *get_share_mode_lock(
+ 					    smb_fname,
+ 					    old_write_time);
+ 	if (!NT_STATUS_IS_OK(status)) {
+-		DBG_DEBUG("get_static_share_mode_data failed: %s\n",
+-			  nt_errstr(status));
+-		TALLOC_FREE(static_share_mode_record);
+-		goto fail;
++		if (NT_STATUS_EQUAL(status, NT_STATUS_NOT_FOUND) &&
++		    (static_share_mode_record_value.dsize != 0)) {
++			status = get_static_share_mode_value_data(
++					static_share_mode_record_value, id);
++
++			if (!NT_STATUS_IS_OK(status)) {
++				DBG_DEBUG("get_static_share_mode_data failed: %s\n",
++					  nt_errstr(status));
++				if (static_share_mode_record_talloced) {
++					TALLOC_FREE(static_share_mode_record);
++				}
++				goto fail;
++			}
++		}
++		else {
++			DBG_DEBUG("get_static_share_mode_data failed: %s\n",
++				  nt_errstr(status));
++			if (static_share_mode_record_talloced) {
++				TALLOC_FREE(static_share_mode_record);
++			}
++			goto fail;
++		}
+ 	}
+ 
+ done:
+-- 
+2.26.1


### PR DESCRIPTION
Samba crashes during time machine backup when trying to TALLOC_FREE the
static shared mode lock data. This is because in the particular code
path in question, the static share mode is not allocated via talloc as
consequeunce of dbwrap abstractions. Address this issue by getting the
static shared mode data via alternative means and continuing. Also add
an extra check to see whether the memory for the data is talloc'ed before
free.