### PR TITLE
NAS-107465 / 20.10 / Ease netconf validation

### DIFF
--- a/net/samba/Makefile
+++ b/net/samba/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			0
+PORTREVISION=			1
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -36,6 +36,7 @@ EXTRA_PATCHES+=			${PATCHDIR}/debug.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/tevent_kqueue.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/allow_vfs_set_sparse.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/dns-fixes.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/ease-netconf-validation.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba/files/ease-netconf-validation.patch
+++ b/net/samba/files/ease-netconf-validation.patch
@@ -1,0 +1,33 @@
+commit 437d1baaf80a2fd3c8e90957087cecc85ba9aa3d
+Author: Andrew <awalker@ixsystems.com>
+Date:   Fri Sep 4 13:24:41 2020 -0400
+
+    s3:util:net_conf - allow empty path for [homes]
+    
+    Validation for "net conf addshare" is overly strict. Empty string for
+    path for homes share is valid.
+    
+    Signed-off-by: Andrew <awalker@ixsystems.com>
+
+diff --git a/source3/utils/net_conf.c b/source3/utils/net_conf.c
+index 267c4c802df..b2d5ebd242a 100644
+--- a/source3/utils/net_conf.c
++++ b/source3/utils/net_conf.c
+@@ -648,10 +648,13 @@ static int net_conf_addshare(struct net_context *c,
+ 	/* validate path */
+ 
+ 	if (path[0] != '/') {
+-		d_fprintf(stderr,
+-			  _("Error: path '%s' is not an absolute path.\n"),
+-			  path);
+-		goto done;
++		if (!strequal(sharename, HOMES_NAME) ||
++		    strlen(path) != 0) {
++			d_fprintf(stderr,
++				  _("Error: path '%s' is not an absolute path.\n"),
++				 path);
++			goto done;
++		}
+ 	}
+ 
+ 	/*


### PR DESCRIPTION
Allow `net conf addshare homes ""` to succeed.