### PR TITLE
NAS-107939 / 12.0 / textproc/libxml2: Multiple vulnerabilities

### DIFF
--- a/textproc/libxml2/Makefile
+++ b/textproc/libxml2/Makefile
@@ -3,10 +3,16 @@
 
 PORTNAME=	libxml2
 DISTVERSION=	2.9.10
-PORTREVISION?=	0
+PORTREVISION?=	1
 CATEGORIES?=	textproc gnome
 MASTER_SITES=	http://xmlsoft.org/sources/
 DIST_SUBDIR=	gnome2
+
+# CVE-2019-20388, CVE-2020-7595, CVE-2020-24977
+PATCH_SITES=	https://gitlab.gnome.org/GNOME/libxml2/commit/
+PATCHFILES=	7ffcd44d7e6c46704f8af0321d9314cd26e0e18a.patch:-p1 \
+		0e1a49c8907645d2e155f0d89d4d9895ac5112b5.patch:-p1 \
+		50f06b3efb638efb0abd95dc62dca05ae67882c2.patch:-p1
 
 MAINTAINER?=	desktop@FreeBSD.org
 COMMENT?=	XML parser library for GNOME

--- a/textproc/libxml2/distinfo
+++ b/textproc/libxml2/distinfo
@@ -1,3 +1,9 @@
-TIMESTAMP = 1573915139
+TIMESTAMP = 1600322449
 SHA256 (gnome2/libxml2-2.9.10.tar.gz) = aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
 SIZE (gnome2/libxml2-2.9.10.tar.gz) = 5624761
+SHA256 (gnome2/7ffcd44d7e6c46704f8af0321d9314cd26e0e18a.patch) = 8bab1a7fcc22a8f9a3f89648660bbca424196d82967e213bd27c1dcc9a9544a5
+SIZE (gnome2/7ffcd44d7e6c46704f8af0321d9314cd26e0e18a.patch) = 1015
+SHA256 (gnome2/0e1a49c8907645d2e155f0d89d4d9895ac5112b5.patch) = 4a1dca36e762a0e2affb0779918fbf1665a00d984ffbd3efa45d3d202f87ea8c
+SIZE (gnome2/0e1a49c8907645d2e155f0d89d4d9895ac5112b5.patch) = 996
+SHA256 (gnome2/50f06b3efb638efb0abd95dc62dca05ae67882c2.patch) = 701048e726e2f3f7f2a71a7054030fc154b5edace72e23c5934ecd9ee09ad811
+SIZE (gnome2/50f06b3efb638efb0abd95dc62dca05ae67882c2.patch) = 1052


### PR DESCRIPTION
Includes upstreams fixes for

	* CVE-2019-20388
	* CVE-2020-7595
	* CVE-2020-24977

PR:		249386
Submitted by:	daniel.engberg.lists@pyret.net
MFH:		2020Q3