### PR TITLE
NAS-106880 / 12.0 / Load registry service before trying to look up user shares

### DIFF
--- a/net/samba/Makefile
+++ b/net/samba/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			1
+PORTREVISION=			2
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -39,6 +39,7 @@ EXTRA_PATCHES+=			${PATCHDIR}/allow_vfs_set_sparse.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/fix-fruit-locking.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/fix-smb2-getquota.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/ease-netconf-validation.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/registry_service.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4

--- a/net/samba/files/registry_service.patch
+++ b/net/samba/files/registry_service.patch
@@ -1,0 +1,15 @@
+diff --git a/source3/param/service.c b/source3/param/service.c
+index 09b8228daad..634ac9e94eb 100644
+--- a/source3/param/service.c
++++ b/source3/param/service.c
+@@ -129,6 +129,10 @@ int find_service(TALLOC_CTX *ctx, const char *service_in, char **p_service_out)
+ 
+ 	iService = lp_servicenumber(*p_service_out);
+ 
++	if (iService < 0) {
++		iService = load_registry_service(*p_service_out);
++	}
++
+ 	/* now handle the special case of a home directory */
+ 	if (iService < 0) {
+ 		char *phome_dir = get_user_home_dir(ctx, *p_service_out);


### PR DESCRIPTION
When there is a name collision between a user home directory and
a registry share, default (non-registry) behavior is to only look
up homes share if lp_servicenumber() fails. Order was reversed for
case of registry shares (user home dirs being preferred) this
causes major POLA violation for end users.