### PR TITLE
Update zettarepl port

### DIFF
--- a/sysutils/py-zettarepl/Makefile
+++ b/sysutils/py-zettarepl/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	zettarepl
 PORTVERSION=	0.1
-PORTREVISION=	28
+PORTREVISION=	29
 CATEGORIES=	sysutils python
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
@@ -13,7 +13,7 @@ USES=		python:3.6+
 USE_PYTHON=	autoplist distutils
 USE_GITHUB=	yes
 GH_ACCOUNT=	freenas
-GH_TAGNAME=	59bde62a63928386bc33d4046211e145dd27bada
+GH_TAGNAME=	142417cbaa3b112ef39c8214cb0edc22eae2fb5a
 
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}coloredlogs>0:devel/py-coloredlogs@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}croniter>0:sysutils/py-croniter@${PY_FLAVOR} \

--- a/sysutils/py-zettarepl/distinfo
+++ b/sysutils/py-zettarepl/distinfo
@@ -1,3 +1,3 @@
 TIMESTAMP = 1572888933
-SHA256 (freenas-zettarepl-0.1-59bde62a63928386bc33d4046211e145dd27bada_GH0.tar.gz) = 522920b72fd8886836196eea1ecef84beb2a80b616851b9df2650ff75c3e1cc6
-SIZE (freenas-zettarepl-0.1-59bde62a63928386bc33d4046211e145dd27bada_GH0.tar.gz) = 73969
+SHA256 (freenas-zettarepl-0.1-142417cbaa3b112ef39c8214cb0edc22eae2fb5a_GH0.tar.gz) = 37c8f9e4ad041134bd9c5d337766c4f7cca826d48e85cdfac684bc537e507dd4
+SIZE (freenas-zettarepl-0.1-142417cbaa3b112ef39c8214cb0edc22eae2fb5a_GH0.tar.gz) = 74487


### PR DESCRIPTION
@william-gr this is a follow-up to "always exclude mountpoint and samba/nfs share properties" fix so it is necessary for U2