### PR TITLE
NAS-110179 / 12.0 / remove grub2 from MOVED file

### DIFF
--- a/MOVED
+++ b/MOVED
@@ -12837,7 +12837,6 @@ lang/dmd2||2019-08-11|Has expired: Broken for more than 6 months and upstream ha
 sysutils/openhpi||2019-08-12|Has expired: Broken for more than 6 months
 textproc/scim-bridge||2019-08-17|Has expired: Broken for more than 6 months
 devel/py-efilter||2019-08-17|Has expired: No longer maintained
-sysutils/grub2||2019-08-17|Has expired: Unmaintained (more than five years), not updated (one-and-a-half years), does not build with modern compilers
 net/samba46|net/samba48|2019-08-19|Has expired: yes
 net/samba47|net/samba48|2019-08-19|Has expired: yes
 palm/bibelot|sysutils/bibelot|2019-08-20|Move to more applicable category


### PR DESCRIPTION
This causes `grub2` to be deleted and rebuilt on every incremental. `py-middlewared` port has a build time dependency on this port which then causes it to rebuilt. This means that `py-midcli` and `freenas-files` etc etc get rebuilt as well.

`grub2` was updated by us to work so remove it from the `MOVED` file which unmarks it as a deprecated port.