### PR TITLE
NAS-110598 / 12.0 / Fix a few python ports for new python extension format

### DIFF
--- a/devel/py-cffi/Makefile
+++ b/devel/py-cffi/Makefile
@@ -27,7 +27,7 @@ CFLAGS+=	-Wno-shift-negative-value
 .endif
 
 post-install:
-	${STRIP_CMD} ${STAGEDIR}${PYTHONPREFIX_SITELIBDIR}/_cffi_backend.so
+	${STRIP_CMD} ${STAGEDIR}${PYTHONPREFIX_SITELIBDIR}/_cffi_backend${PYTHON_EXT_SUFFIX}.so
 
 do-test:
 	@(cd ${TEST_WRKSRC} && ${SETENV} ${MAKE_ENV} ${PYTHON_CMD} ${PYDISTUTILS_SETUP} build_ext -i)

--- a/textproc/py-MarkupSafe/Makefile
+++ b/textproc/py-MarkupSafe/Makefile
@@ -17,6 +17,6 @@ USES=		python
 USE_PYTHON=	autoplist concurrent distutils
 
 post-install:
-	${STRIP_CMD} ${STAGEDIR}${PYTHON_SITELIBDIR}/markupsafe/_speedups.so
+	${STRIP_CMD} ${STAGEDIR}${PYTHON_SITELIBDIR}/markupsafe/_speedups${PYTHON_EXT_SUFFIX}.so
 
 .include <bsd.port.mk>

--- a/textproc/py-pystemmer/Makefile
+++ b/textproc/py-pystemmer/Makefile
@@ -19,6 +19,6 @@ USES=		python
 USE_PYTHON=	autoplist cython distutils
 
 post-install:
-	${STRIP_CMD} ${STAGEDIR}${PYTHONPREFIX_SITELIBDIR}/Stemmer.so
+	${STRIP_CMD} ${STAGEDIR}${PYTHONPREFIX_SITELIBDIR}/Stemmer${PYTHON_EXT_SUFFIX}.so
 
 .include <bsd.port.mk>


### PR DESCRIPTION
devel/py-cffi, textproc/py-MarkupSafe, and textproc/py-pystemmer
were build dependencies when I was running a batch install of
the Samba port. They're currently broken in ports because of
python changes adding a new extension to .so files. This PR
contains the minimum changes to have Samba build successfully
in a pristine enviornment.