### PR TITLE
NAS-111158 / 13.0 / fix 13.0 build by updating wireguard-kmod port

### DIFF
--- a/net/wireguard-kmod/Makefile
+++ b/net/wireguard-kmod/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wireguard-kmod
-PORTVERSION=	0.0.20210428
+PORTVERSION=	0.0.20210502
 CATEGORIES=	net net-vpn
 MASTER_SITES=	https://git.zx2c4.com/wireguard-freebsd/snapshot/
 DISTNAME=	wireguard-freebsd-${PORTVERSION}

--- a/net/wireguard-kmod/Makefile
+++ b/net/wireguard-kmod/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wireguard-kmod
-PORTVERSION=	0.0.20210502
+PORTVERSION=	0.0.20210503
 CATEGORIES=	net net-vpn
 MASTER_SITES=	https://git.zx2c4.com/wireguard-freebsd/snapshot/
 DISTNAME=	wireguard-freebsd-${PORTVERSION}

--- a/net/wireguard-kmod/Makefile
+++ b/net/wireguard-kmod/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wireguard-kmod
-PORTVERSION=	0.0.20210503
+PORTVERSION=	0.0.20210606
 CATEGORIES=	net net-vpn
 MASTER_SITES=	https://git.zx2c4.com/wireguard-freebsd/snapshot/
 DISTNAME=	wireguard-freebsd-${PORTVERSION}

--- a/net/wireguard-kmod/Makefile
+++ b/net/wireguard-kmod/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	wireguard-kmod
 PORTVERSION=	0.0.20210606
+PORTREVISION=	1
 CATEGORIES=	net net-vpn
 MASTER_SITES=	https://git.zx2c4.com/wireguard-freebsd/snapshot/
 DISTNAME=	wireguard-freebsd-${PORTVERSION}

--- a/net/wireguard-kmod/distinfo
+++ b/net/wireguard-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1619688377
-SHA256 (wireguard-freebsd-0.0.20210428.tar.xz) = cceebd8f3f21d522342b3629fa0350e4fbc64a00035d330f82301741e56def46
-SIZE (wireguard-freebsd-0.0.20210428.tar.xz) = 50404
+TIMESTAMP = 1620052580
+SHA256 (wireguard-freebsd-0.0.20210502.tar.xz) = cd59a0a711308083e40ac5e7e26abc63c8b1f4615a9d66f73f2398388b8e7b9b
+SIZE (wireguard-freebsd-0.0.20210502.tar.xz) = 50464

--- a/net/wireguard-kmod/distinfo
+++ b/net/wireguard-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1620052580
-SHA256 (wireguard-freebsd-0.0.20210502.tar.xz) = cd59a0a711308083e40ac5e7e26abc63c8b1f4615a9d66f73f2398388b8e7b9b
-SIZE (wireguard-freebsd-0.0.20210502.tar.xz) = 50464
+TIMESTAMP = 1620293210
+SHA256 (wireguard-freebsd-0.0.20210503.tar.xz) = 96b2bceadc05dac2f026e203d1c0d25f114491afc8fbfc8d6f71c3de7f4a22f1
+SIZE (wireguard-freebsd-0.0.20210503.tar.xz) = 50548

--- a/net/wireguard-kmod/distinfo
+++ b/net/wireguard-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1620293210
-SHA256 (wireguard-freebsd-0.0.20210503.tar.xz) = 96b2bceadc05dac2f026e203d1c0d25f114491afc8fbfc8d6f71c3de7f4a22f1
-SIZE (wireguard-freebsd-0.0.20210503.tar.xz) = 50548
+TIMESTAMP = 1623000437
+SHA256 (wireguard-freebsd-0.0.20210606.tar.xz) = d7501666030619e4ee86e68d2b9fd6a718be6541be83bf726414b821c60383d0
+SIZE (wireguard-freebsd-0.0.20210606.tar.xz) = 45920

--- a/net/wireguard-kmod/files/patch-compat.h
+++ b/net/wireguard-kmod/files/patch-compat.h
@@ -1,0 +1,22 @@
+From 64a507ad6b3c7e8455c67b452160b9e4211fd872 Mon Sep 17 00:00:00 2001
+From: "Jason A. Donenfeld" <Jason@zx2c4.com>
+Date: Mon, 7 Jun 2021 11:50:20 +0200
+Subject: compat: taskqueue draining was backported to stable/13
+
+Since 407b687dfef ("Make sure all tasklets are drained before unloading
+the LinuxKPI. Else use-after-free may happen."), stable/13 now has the
+taskqueue API that we need.
+
+Reported-by: Herbert J. Skuhra <herbert@gojira.at>
+Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>
+--- compat.h.orig	2021-06-06 13:35:25 UTC
++++ compat.h
+@@ -8,7 +8,7 @@
+ 
+ #include <sys/param.h>
+ 
+-#if __FreeBSD_version < 1400000
++#if __FreeBSD_version < 1300507
+ #include <sys/smp.h>
+ #include <sys/gtaskqueue.h>
+ 


### PR DESCRIPTION
Fix the `truenas/13.0-stable` based builds by updating the `wireguard-kmod` port to latest upstream.