### PR TITLE
NAS-111357 / 12.0 / update python to 3.9.6 from 3.9.5

### DIFF
--- a/lang/python39/Makefile.version
+++ b/lang/python39/Makefile.version
@@ -3,4 +3,4 @@
 
 # Do not forget to update python documentation (lang/python-doc-*)
 # Run "make -C lang/python-doc-html makesum"
-PYTHON_PORTVERSION=	3.9.5
+PYTHON_PORTVERSION=	3.9.6

--- a/lang/python39/distinfo
+++ b/lang/python39/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1620588345
-SHA256 (python/Python-3.9.5.tar.xz) = 0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83
-SIZE (python/Python-3.9.5.tar.xz) = 19058600
+TIMESTAMP = 1625323735
+SHA256 (python/Python-3.9.6.tar.xz) = 397920af33efc5b97f2e0b57e91923512ef89fc5b3c1d21dbfc8c4828ce0108a
+SIZE (python/Python-3.9.6.tar.xz) = 19051972

--- a/lang/python39/pkg-plist
+++ b/lang/python39/pkg-plist
@@ -2186,7 +2186,7 @@ lib/python%%XYDOT%%/ensurepip/_bundled/__init__.py
 lib/python%%XYDOT%%/ensurepip/_bundled/__pycache__/__init__.cpython-%%XY%%.opt-1.pyc
 lib/python%%XYDOT%%/ensurepip/_bundled/__pycache__/__init__.cpython-%%XY%%.opt-2.pyc
 lib/python%%XYDOT%%/ensurepip/_bundled/__pycache__/__init__.cpython-%%XY%%.pyc
-lib/python%%XYDOT%%/ensurepip/_bundled/pip-21.1.1-py3-none-any.whl
+lib/python%%XYDOT%%/ensurepip/_bundled/pip-21.1.3-py3-none-any.whl
 lib/python%%XYDOT%%/ensurepip/_bundled/setuptools-56.0.0-py3-none-any.whl
 lib/python%%XYDOT%%/ensurepip/_uninstall.py
 lib/python%%XYDOT%%/enum.py


### PR DESCRIPTION
Changes:	https://docs.python.org/release/3.9.6/whatsnew/changelog.html

Fixes CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29921