### PR TITLE
NAS-113195 / 12.0 / Update net/samba to 4.13.14

### DIFF
--- a/net/samba/Makefile
+++ b/net/samba/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=			${SAMBA4_BASENAME}
 PORTVERSION=			${SAMBA4_VERSION}
-PORTREVISION=			2
+PORTREVISION=			1
 CATEGORIES?=			net
 MASTER_SITES=			SAMBA/samba/stable SAMBA/samba/rc
 DISTNAME=			${SAMBA4_DISTNAME}
@@ -36,10 +36,11 @@ EXTRA_PATCHES+=			${PATCHDIR}/allow_vfs_set_sparse.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/ease-netconf-validation.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/registry_service.patch:-p1
 EXTRA_PATCHES+=			${PATCHDIR}/full_audit.patch:-p1
+EXTRA_PATCHES+=			${PATCHDIR}/trusted_domain_fix.patch:-p1
 
 SAMBA4_BASENAME=		samba
 SAMBA4_PORTNAME=		${SAMBA4_BASENAME}4
-SAMBA4_VERSION=			4.13.13
+SAMBA4_VERSION=			4.13.14
 SAMBA4_DISTNAME=		${SAMBA4_BASENAME}-${SAMBA4_VERSION:S|.p|pre|:S|.r|rc|:S|.t|tp|:S|.a|alpha|}
 
 WRKSRC?=			${WRKDIR}/${DISTNAME}

--- a/net/samba/distinfo
+++ b/net/samba/distinfo
@@ -1,3 +1,3 @@
 TIMESTAMP = 1593688384
-SIZE (samba-4.13.13.tar.gz) = 18871574
-SHA256 (samba-4.13.13.tar.gz) = 2a6d9ddad5c06b3c5b593f8981a2ff3a201095c912d9ae68e7d4fe7cb5aa5f3f
+SIZE (samba-4.13.14.tar.gz) = 18943381
+SHA256 (samba-4.13.14.tar.gz) = 6611a8e8fa93ea0cb3ee2cadd6269305ded40acf7f8b6a7576547e5d13f07f80

--- a/net/samba/files/trusted_domain_fix.patch
+++ b/net/samba/files/trusted_domain_fix.patch
@@ -1,0 +1,39 @@
+From 21ee75079ec354e2e5ba3252cdc63be4da059413 Mon Sep 17 00:00:00 2001
+From: Andrew Walker <awalker@ixsystems.com>
+Date: Tue, 9 Nov 2021 13:46:45 -0500
+Subject: [PATCH] s3/winbindd/winbindd_util - fix "allow trusted domains"
+
+At bypass for BUILTIN (S-1-5-32) domain if
+"allow trusted domains" is disabled.
+---
+ source3/winbindd/winbindd_util.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/source3/winbindd/winbindd_util.c b/source3/winbindd/winbindd_util.c
+index 1ae4a8d3ca3..20f13fcaa21 100644
+--- a/source3/winbindd/winbindd_util.c
++++ b/source3/winbindd/winbindd_util.c
+@@ -125,13 +125,19 @@ static NTSTATUS add_trusted_domain(const char *domain_name,
+ 	struct winbindd_domain *domain = NULL;
+ 	int role = lp_server_role();
+ 	struct dom_sid_buf buf;
++	bool is_builtin = false;
+ 
+ 	if (is_null_sid(sid)) {
+ 		DBG_ERR("Got null SID for domain [%s]\n", domain_name);
+ 		return NT_STATUS_INVALID_PARAMETER;
+ 	}
+ 
+-	if (!is_allowed_domain(domain_name)) {
++	if (strequal(domain_name, "BUILTIN") &&
++	    sid_check_is_builtin(sid)) {
++		is_builtin = True;
++	}
++
++	if (!is_builtin && !is_allowed_domain(domain_name)) {
+ 		return NT_STATUS_NO_SUCH_DOMAIN;
+ 	}
+ 
+-- 
+2.26.2
+

--- a/net/samba/pkg-plist
+++ b/net/samba/pkg-plist
@@ -287,7 +287,7 @@ lib/samba4/private/libposix-eadb-samba4.so
 lib/samba4/private/libprinter-driver-samba4.so
 lib/samba4/private/libprinting-migrate-samba4.so
 lib/samba4/private/libpyldb-util%%PYTHON_EXT_SUFFIX%%.so.2
-lib/samba4/private/libpyldb-util%%PYTHON_EXT_SUFFIX%%.so.2.2.2
+lib/samba4/private/libpyldb-util%%PYTHON_EXT_SUFFIX%%.so.2.2.3
 lib/samba4/private/libpytalloc-util%%PYTHON_EXT_SUFFIX%%.so.2
 lib/samba4/private/libpytalloc-util%%PYTHON_EXT_SUFFIX%%.so.2.3.1
 lib/samba4/private/libregistry-samba4.so
@@ -764,7 +764,7 @@ man/man8/winbindd.8.gz
 %%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldb-cmdline-samba4.so
 %%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldbsamba-samba4.so
 %%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldb.so.2
-%%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldb.so.2.2.2
+%%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldb.so.2.2.3
 %%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldb-key-value-samba4.so
 %%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldb-tdb-err-map-samba4.so
 %%SAMBA4_BUNDLED_LDB%%lib/samba4/private/libldb-tdb-int-samba4.so


### PR DESCRIPTION
https://www.samba.org/samba/history/samba-4.13.14.html

This is a security release in order to address the following defects:

o CVE-2016-2124:  SMB1 client connections can be downgraded to plaintext
                  authentication.
                  https://www.samba.org/samba/security/CVE-2016-2124.html

o CVE-2020-25717: A user on the domain can become root on domain members.
                  https://www.samba.org/samba/security/CVE-2020-25717.html
                  (PLEASE READ! There are important behaviour changes described)

o CVE-2020-25718: Samba AD DC did not correctly sandbox Kerberos tickets issued
                  by an RODC.
                  https://www.samba.org/samba/security/CVE-2020-25718.html

o CVE-2020-25719: Samba AD DC did not always rely on the SID and PAC in Kerberos
                  tickets.
                  https://www.samba.org/samba/security/CVE-2020-25719.html

o CVE-2020-25721: Kerberos acceptors need easy access to stable AD identifiers
                  (eg objectSid).
                  https://www.samba.org/samba/security/CVE-2020-25721.html

o CVE-2020-25722: Samba AD DC did not do suffienct access and conformance
                  checking of data stored.
                  https://www.samba.org/samba/security/CVE-2020-25722.html

o CVE-2021-3738:  Use after free in Samba AD DC RPC server.
                  https://www.samba.org/samba/security/CVE-2021-3738.html

o CVE-2021-23192: Subsequent DCE/RPC fragment injection vulnerability.
                  https://www.samba.org/samba/security/CVE-2021-23192.html