### PR TITLE
NAS-115532 / 12.0 / net/netatalk3 - fix multiple CVEs

### DIFF
--- a/net/netatalk3/Makefile
+++ b/net/netatalk3/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	netatalk
 PORTVERSION=	3.1.12
-PORTREVISION=	5
+PORTREVISION=	7
 PORTEPOCH=	1
 CATEGORIES=	net
 MASTER_SITES=	SF
@@ -25,6 +25,7 @@ GNU_CONFIGURE=	yes
 USE_LDCONFIG=	yes
 USE_RC_SUBR=	netatalk
 INSTALL_TARGET=install-strip
+EXTRA_PATCHES+=		${PATCHDIR}/CVE_FIXES.patch:-p1
 
 CONFIGURE_ARGS+=	--with-pkgconfdir=${PREFIX}/etc \
 			--with-libgcrypt-dir=${LOCALBASE} \

--- a/net/netatalk3/files/CVE_FIXES.patch
+++ b/net/netatalk3/files/CVE_FIXES.patch
@@ -1,0 +1,344 @@
+diff --git a/NEWS b/NEWS
+index 1c5be553..71f6e466 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,3 +1,13 @@
++Changes in 3.1.13
++=================
++* FIX: CVE-2021-31439
++* FIX: CVE-2022-23121
++* FIX: CVE-2022-23123
++* FIX: CVE-2022-23122
++* FIX: CVE-2022-23125
++* FIX: CVE-2022-23124
++* FIX: CVE-2022-0194
++
+ Changes in 3.1.12
+ =================
+ * FIX: dhx uams: build with LibreSSL, GitHub#91
+diff --git a/etc/afpd/appl.c b/etc/afpd/appl.c
+index f53803e0..be4ba4d3 100644
+--- a/etc/afpd/appl.c
++++ b/etc/afpd/appl.c
+@@ -95,6 +95,11 @@ static int copyapplfile(int sfd, int dfd, char *mpath, u_short mplen)
+         p = buf + sizeof(appltag);
+         memcpy( &len, p, sizeof(len));
+         len = ntohs( len );
++        if (len > MAXPATHLEN - (sizeof(appltag) + sizeof(len))) {
++            errno = EINVAL;
++            cc = -1;
++            break;
++        }
+         p += sizeof( len );
+         if (( cc = read( sa.sdt_fd, p, len )) < len ) {
+             break;
+diff --git a/include/atalk/adouble.h b/include/atalk/adouble.h
+index 2df806d1..2b79bd98 100644
+--- a/include/atalk/adouble.h
++++ b/include/atalk/adouble.h
+@@ -110,6 +110,8 @@
+ #define ADEDLEN_MACFILEI        4
+ #define ADEDLEN_PRODOSFILEI     8
+ #define ADEDLEN_MSDOSFILEI      2
++#define ADEDLEN_ICONBW          128
++#define ADEDLEN_ICONCOL         1024
+ #define ADEDLEN_DID             4
+ #define ADEDLEN_PRIVDEV         8
+ #define ADEDLEN_PRIVINO         8
+@@ -222,6 +224,7 @@ struct adouble {
+     char                *ad_name;          /* mac name (maccharset or UTF8-MAC)       */
+     struct adouble_fops *ad_ops;
+     uint16_t            ad_open_forks;     /* open forks (by others)                  */
++    size_t              valid_data_len;	   /* Bytes read into ad_data                 */
+     char                ad_data[AD_DATASZ_MAX];
+ };
+ 
+@@ -369,7 +372,6 @@ struct adouble {
+ #define ad_getentrylen(ad,eid)     ((ad)->ad_eid[(eid)].ade_len)
+ #define ad_setentrylen(ad,eid,len) ((ad)->ad_eid[(eid)].ade_len = (len))
+ #define ad_setentryoff(ad,eid,off) ((ad)->ad_eid[(eid)].ade_off = (off))
+-#define ad_entry(ad,eid)           ((caddr_t)(ad)->ad_data + (ad)->ad_eid[(eid)].ade_off)
+ 
+ #define ad_get_RF_flags(ad) ((ad)->ad_rfp->adf_flags)
+ #define ad_get_MD_flags(ad) ((ad)->ad_mdp->adf_flags)
+@@ -397,6 +399,7 @@ extern void ad_unlock(struct adouble *, int fork, int unlckbrl);
+ extern int ad_tmplock(struct adouble *, uint32_t eid, int type, off_t off, off_t len, int fork);
+ 
+ /* ad_open.c */
++extern void *ad_entry(const struct adouble *ad, int eid);
+ extern off_t ad_getentryoff(const struct adouble *ad, int eid);
+ extern const char *adflags2logstr(int adflags);
+ extern int ad_setfuid     (const uid_t );
+diff --git a/libatalk/adouble/ad_open.c b/libatalk/adouble/ad_open.c
+index ee784d22..b7169ecf 100644
+--- a/libatalk/adouble/ad_open.c
++++ b/libatalk/adouble/ad_open.c
+@@ -398,10 +398,10 @@ static int new_ad_header(struct adouble *ad, const char *path, struct stat *stp,
+ /**
+  * Read an AppleDouble buffer, returns 0 on success, -1 if an entry was malformatted
+  **/
+-static int parse_entries(struct adouble *ad, char *buf, uint16_t nentries)
++static int parse_entries(struct adouble *ad, uint16_t nentries, size_t valid_data_len)
+ {
+     uint32_t   eid, len, off;
+-    int        ret = 0;
++    uint8_t *buf = ad->ad_data + AD_HEADER_LEN;
+ 
+     /* now, read in the entry bits */
+     for (; nentries > 0; nentries-- ) {
+@@ -415,21 +415,21 @@ static int parse_entries(struct adouble *ad, char *buf, uint16_t nentries)
+         len = ntohl( len );
+         buf += sizeof( len );
+ 
+-        ad->ad_eid[eid].ade_off = off;
+-        ad->ad_eid[eid].ade_len = len;
+-
+         if (!eid
+             || eid > ADEID_MAX
+-            || off >= sizeof(ad->ad_data)
+-            || ((eid != ADEID_RFORK) && (off + len >  sizeof(ad->ad_data))))
++            || off >= valid_data_len
++            || ((eid != ADEID_RFORK) && (off + len >  valid_data_len)))
+         {
+-            ret = -1;
+             LOG(log_warning, logtype_ad, "parse_entries: bogus eid: %u, off: %u, len: %u",
+                 (uint)eid, (uint)off, (uint)len);
++	    return -1;
+         }
++        ad->ad_eid[eid].ade_off = off;
++        ad->ad_eid[eid].ade_len = len;
+     }
+ 
+-    return ret;
++    ad->valid_data_len = valid_data_len;
++    return 0;
+ }
+ 
+ /* this reads enough of the header so that we can figure out all of
+@@ -443,7 +443,6 @@ static int ad_header_read(const char *path, struct adouble *ad, const struct sta
+ {
+     char                *buf = ad->ad_data;
+     uint16_t            nentries;
+-    int                 len;
+     ssize_t             header_len;
+     struct stat         st;
+ 
+@@ -469,25 +468,19 @@ static int ad_header_read(const char *path, struct adouble *ad, const struct sta
+ 
+     memcpy(&nentries, buf + ADEDOFF_NENTRIES, sizeof( nentries ));
+     nentries = ntohs( nentries );
++    if (nentries > 16) {
++        LOG(log_error, logtype_ad, "ad_open: too many entries: %"PRIu16, nentries);
++        errno = EIO;
++        return -1;
++    }
+ 
+-    /* read in all the entry headers. if we have more than the
+-     * maximum, just hope that the rfork is specified early on. */
+-    len = nentries*AD_ENTRY_LEN;
+-
+-    if (len + AD_HEADER_LEN > sizeof(ad->ad_data))
+-        len = sizeof(ad->ad_data) - AD_HEADER_LEN;
+-
+-    buf += AD_HEADER_LEN;
+-    if (len > header_len - AD_HEADER_LEN) {
+-        LOG(log_error, logtype_ad, "ad_header_read: can't read entry info.");
++    if ((nentries * AD_ENTRY_LEN) + AD_HEADER_LEN > header_len) {
++        LOG(log_error, logtype_ad, "ad_header_read: too many entries: %zd", header_len);
+         errno = EIO;
+         return -1;
+     }
+ 
+-    /* figure out all of the entry offsets and lengths. if we aren't
+-     * able to read a resource fork entry, bail. */
+-    nentries = len / AD_ENTRY_LEN;
+-    if (parse_entries(ad, buf, nentries) != 0) {
++    if (parse_entries(ad, nentries, header_len) != 0) {
+         LOG(log_warning, logtype_ad, "ad_header_read(%s): malformed AppleDouble",
+             path ? fullpathname(path) : "");
+         errno = EIO;
+@@ -649,7 +642,6 @@ static int ad_header_read_osx(const char *path, struct adouble *ad, const struct
+     struct adouble      adosx;
+     char                *buf;
+     uint16_t            nentries;
+-    int                 len;
+     ssize_t             header_len;
+     struct stat         st;
+     int                 retry_read = 0;
+@@ -682,22 +674,23 @@ reread:
+ 
+     memcpy(&nentries, buf + ADEDOFF_NENTRIES, sizeof( nentries ));
+     nentries = ntohs(nentries);
+-    len = nentries * AD_ENTRY_LEN;
+-
+-    if (len + AD_HEADER_LEN > sizeof(adosx.ad_data))
+-        len = sizeof(adosx.ad_data) - AD_HEADER_LEN;
++    if (nentries > 16) {
++        LOG(log_error, logtype_ad, "ad_header_read_osx: too many entries: %"PRIu16, nentries);
++        errno = EIO;
++        return -1;
++    }
+ 
+-    buf += AD_HEADER_LEN;
+-    if (len > header_len - AD_HEADER_LEN) {
+-        LOG(log_error, logtype_ad, "ad_header_read_osx: can't read entry info.");
++    if ((nentries * AD_ENTRY_LEN) + AD_HEADER_LEN > header_len) {
++        LOG(log_error, logtype_ad, "ad_header_read_osx: too many entries: %zd", header_len);
+         errno = EIO;
+         return -1;
+     }
+ 
+-    nentries = len / AD_ENTRY_LEN;
+-    if (parse_entries(&adosx, buf, nentries) != 0) {
++    if (parse_entries(&adosx, nentries, header_len) != 0) {
+         LOG(log_warning, logtype_ad, "ad_header_read(%s): malformed AppleDouble",
+             path ? fullpathname(path) : "");
++            errno = EIO;
++            EC_FAIL;
+     }
+ 
+     if (ad_getentrylen(&adosx, ADEID_FINDERI) != ADEDLEN_FINDERI) {
+@@ -782,7 +775,7 @@ static int ad_header_read_ea(const char *path, struct adouble *ad, const struct
+     }
+ 
+     /* Now parse entries */
+-    if (parse_entries(ad, buf + AD_HEADER_LEN, nentries)) {
++    if (parse_entries(ad, nentries, header_len)) {
+         LOG(log_warning, logtype_ad, "ad_header_read(%s): malformed AppleDouble",
+             path ? fullpathname(path) : "");
+         errno = EINVAL;
+@@ -1540,6 +1533,122 @@ static int ad_open_rf(const char *path, int adflags, int mode, struct adouble *a
+  * API functions
+  ********************************************************************************* */
+ 
++/*
++ * All entries besides FinderInfo and resource fork must fit into the
++ * buffer. FinderInfo is special as it may be larger then the default 32 bytes
++ * if it contains marshalled xattrs, which we will fixup that in
++ * ad_convert(). The first 32 bytes however must also be part of the buffer.
++ *
++ * The resource fork is never accessed directly by the ad_data buf.
++ */
++static bool ad_entry_check_size(uint32_t eid,
++				size_t bufsize,
++				uint32_t off,
++				uint32_t got_len)
++{
++	struct {
++		off_t expected_len;
++		bool fixed_size;
++		bool minimum_size;
++	} ad_checks[] = {
++		[ADEID_DFORK] = {-1, false, false}, /* not applicable */
++		[ADEID_RFORK] = {-1, false, false}, /* no limit */
++		[ADEID_NAME] = {ADEDLEN_NAME, false, false},
++		[ADEID_COMMENT] = {ADEDLEN_COMMENT, false, false},
++		[ADEID_ICONBW] = {ADEDLEN_ICONBW, true, false},
++		[ADEID_ICONCOL] = {ADEDLEN_ICONCOL, false, false},
++		[ADEID_FILEI] = {ADEDLEN_FILEI, true, false},
++		[ADEID_FILEDATESI] = {ADEDLEN_FILEDATESI, true, false},
++		[ADEID_FINDERI] = {ADEDLEN_FINDERI, false, true},
++		[ADEID_MACFILEI] = {ADEDLEN_MACFILEI, true, false},
++		[ADEID_PRODOSFILEI] = {ADEDLEN_PRODOSFILEI, true, false},
++		[ADEID_MSDOSFILEI] = {ADEDLEN_MSDOSFILEI, true, false},
++		[ADEID_SHORTNAME] = {ADEDLEN_SHORTNAME, false, false},
++		[ADEID_AFPFILEI] = {ADEDLEN_AFPFILEI, true, false},
++		[ADEID_DID] = {ADEDLEN_DID, true, false},
++		[ADEID_PRIVDEV] = {ADEDLEN_PRIVDEV, true, false},
++		[ADEID_PRIVINO] = {ADEDLEN_PRIVINO, true, false},
++		[ADEID_PRIVSYN] = {ADEDLEN_PRIVSYN, true, false},
++		[ADEID_PRIVID] = {ADEDLEN_PRIVID, true, false},
++	};
++    uint32_t required_len;
++
++	if (eid >= ADEID_MAX) {
++		return false;
++	}
++	if (got_len == 0) {
++		/* Entry present, but empty, allow */
++		return true;
++	}
++	if (ad_checks[eid].expected_len == 0) {
++		/*
++		 * Shouldn't happen: implicitly initialized to zero because
++		 * explicit initializer missing.
++		 */
++		return false;
++	}
++	if (ad_checks[eid].expected_len == -1) {
++		/* Unused or no limit */
++		return true;
++	}
++	if (ad_checks[eid].fixed_size) {
++		if (ad_checks[eid].expected_len != got_len) {
++			/* Wrong size fo fixed size entry. */
++			return false;
++		}
++        required_len = got_len;
++	} else {
++		if (ad_checks[eid].minimum_size) {
++			if (got_len < ad_checks[eid].expected_len) {
++				/*
++				 * Too small for variable sized entry with
++				 * minimum size.
++				 */
++				return false;
++			}
++        required_len = got_len;
++		} else {
++			if (got_len > ad_checks[eid].expected_len) {
++				/* Too big for variable sized entry. */
++				return false;
++			}
++            /*
++             * Expect the buffer to provide enough room for the maximum possible
++             * size.
++             */
++            required_len = ad_checks[eid].expected_len;
++		}
++	}
++	if (off + required_len < off) {
++		/* wrap around */
++		return false;
++	}
++	if (off + required_len > bufsize) {
++		/* overflow */
++		return false;
++	}
++	return true;
++}
++
++void *ad_entry(const struct adouble *ad, int eid)
++{
++	size_t bufsize = ad->valid_data_len;
++	off_t off = ad_getentryoff(ad, eid);
++	size_t len = ad_getentrylen(ad, eid);
++	bool valid;
++
++	valid = ad_entry_check_size(eid, bufsize, off, len);
++	if (!valid) {
++		return NULL;
++	}
++
++	if (off == 0 || len == 0) {
++		return NULL;
++	}
++
++	return ((struct adouble *)ad)->ad_data + off;
++}
++
+ off_t ad_getentryoff(const struct adouble *ad, int eid)
+ {
+     if (ad->ad_vers == AD_VERSION2)
+diff --git a/libatalk/dsi/dsi_stream.c b/libatalk/dsi/dsi_stream.c
+index c8f859ce..479d3ca4 100644
+--- a/libatalk/dsi/dsi_stream.c
++++ b/libatalk/dsi/dsi_stream.c
+@@ -624,6 +624,7 @@ int dsi_stream_receive(DSI *dsi)
+   
+   /* make sure we don't over-write our buffers. */
+   dsi->cmdlen = MIN(ntohl(dsi->header.dsi_len), dsi->server_quantum);
++  dsi->header.dsi_data.dsi_doff = MIN(dsi->header.dsi_data.dsi_doff, dsi->server_quantum);
+ 
+   /* Receiving DSIWrite data is done in AFP function, not here */
+   if (dsi->header.dsi_data.dsi_doff) {


### PR DESCRIPTION
This commit consolidates the following commits into a single
patch file.

64f36724 NEWS: CVEs
d801ed42 CVE-2022-23125: harden copyapplfile()
4a8f6c96 CVE-2022-23123: libatalk: harden ad_entry()
a6fbccb0 CVE-2022-23123: libatalk: add defines for icon lengths
0c0465e4 CVE-2022-23121: apply hardening to parse_entries()
62d4013c CVE-2022-23121: libatalk: apply some hardening to ad_header_read[_osx]()
779717df CVE-2021-31439: libatalk: apply limit checking to DSI write offset

Original PR: https://github.com/truenas/ports/pull/1175
Jira URL: https://jira.ixsystems.com/browse/NAS-115532