### PR TITLE
NAS-115575 / 13.0 / fix graphics/drm-fbsd13-kmod

### DIFF
--- a/graphics/drm-current-kmod/Makefile
+++ b/graphics/drm-current-kmod/Makefile
@@ -1,7 +1,7 @@
 # Created by: Johannes Dieterich <jmd@FreeBSD.org>
 
 PORTNAME=	drm-current-kmod
-PORTVERSION=	5.4.144.g20211230
+PORTVERSION=	5.4.144.g20220128
 CATEGORIES=	graphics kld
 
 MAINTAINER=	x11@FreeBSD.org
@@ -28,7 +28,7 @@ USES=		kmod uidfix compiler:c++11-lang
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	drm-kmod
-GH_TAGNAME=	drm_v5.4.144_4
+GH_TAGNAME=	drm_v5.4.144_5
 
 .include <bsd.port.options.mk>
 

--- a/graphics/drm-current-kmod/Makefile
+++ b/graphics/drm-current-kmod/Makefile
@@ -1,7 +1,7 @@
 # Created by: Johannes Dieterich <jmd@FreeBSD.org>
 
 PORTNAME=	drm-current-kmod
-PORTVERSION=	5.4.144.g20220128
+PORTVERSION=	5.4.144.g20220223
 CATEGORIES=	graphics kld
 
 MAINTAINER=	x11@FreeBSD.org
@@ -28,7 +28,7 @@ USES=		kmod uidfix compiler:c++11-lang
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	drm-kmod
-GH_TAGNAME=	drm_v5.4.144_5
+GH_TAGNAME=	drm_v5.4.144_6
 
 .include <bsd.port.options.mk>
 

--- a/graphics/drm-current-kmod/distinfo
+++ b/graphics/drm-current-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1643363779
-SHA256 (freebsd-drm-kmod-5.4.144.g20220128-drm_v5.4.144_5_GH0.tar.gz) = 43733caa354ee7fd01848ca3a91597f9dc0795f0b0aa2e29d07f23b27dcd5a87
-SIZE (freebsd-drm-kmod-5.4.144.g20220128-drm_v5.4.144_5_GH0.tar.gz) = 18822689
+TIMESTAMP = 1645628224
+SHA256 (freebsd-drm-kmod-5.4.144.g20220223-drm_v5.4.144_6_GH0.tar.gz) = a3c9aa4ebbdc5f40ac0ac4a4b51736d788d0a50428a0ae39a251975c9cb5aca8
+SIZE (freebsd-drm-kmod-5.4.144.g20220223-drm_v5.4.144_6_GH0.tar.gz) = 18822252

--- a/graphics/drm-current-kmod/distinfo
+++ b/graphics/drm-current-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1640810754
-SHA256 (freebsd-drm-kmod-5.4.144.g20211230-drm_v5.4.144_4_GH0.tar.gz) = e8a5c91ff6d0e361ec88d4ec0758b151d7aac6f1799d5852c8928a1e9fb87060
-SIZE (freebsd-drm-kmod-5.4.144.g20211230-drm_v5.4.144_4_GH0.tar.gz) = 18820971
+TIMESTAMP = 1643363779
+SHA256 (freebsd-drm-kmod-5.4.144.g20220128-drm_v5.4.144_5_GH0.tar.gz) = 43733caa354ee7fd01848ca3a91597f9dc0795f0b0aa2e29d07f23b27dcd5a87
+SIZE (freebsd-drm-kmod-5.4.144.g20220128-drm_v5.4.144_5_GH0.tar.gz) = 18822689

--- a/graphics/drm-devel-kmod/Makefile
+++ b/graphics/drm-devel-kmod/Makefile
@@ -1,7 +1,7 @@
 # Created by: Johannes Dieterich <jmd@FreeBSD.org>
 
 PORTNAME=	drm-devel-kmod
-PORTVERSION=	5.5.19.g20211230
+PORTVERSION=	5.7.19.g20220126
 CATEGORIES=	graphics kld
 
 MAINTAINER=	x11@FreeBSD.org
@@ -24,12 +24,12 @@ USES=		kmod uidfix compiler:c++11-lang
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	drm-kmod
-GH_TAGNAME=	drm_v5.5.19_7
+GH_TAGNAME=	drm_v5.7.19
 
 .include <bsd.port.options.mk>
 
-.if ${OPSYS} == FreeBSD && (${OSVERSION} < 1300513 || \
-	(${OSVERSION} < 1400024 && ${OSVERSION} >= 1400000))
+.if ${OPSYS} == FreeBSD && (${OSVERSION} < 1300525 || \
+	(${OSVERSION} < 1400047 && ${OSVERSION} >= 1400000))
 IGNORE=		not supported on older CURRENT/STABLE, no kernel support
 .endif
 .if ${OPSYS} != FreeBSD

--- a/graphics/drm-devel-kmod/Makefile
+++ b/graphics/drm-devel-kmod/Makefile
@@ -1,7 +1,7 @@
 # Created by: Johannes Dieterich <jmd@FreeBSD.org>
 
 PORTNAME=	drm-devel-kmod
-PORTVERSION=	5.7.19.g20220202
+PORTVERSION=	5.7.19.g20220213
 CATEGORIES=	graphics kld
 
 MAINTAINER=	x11@FreeBSD.org
@@ -24,7 +24,7 @@ USES=		kmod uidfix compiler:c++11-lang
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	drm-kmod
-GH_TAGNAME=	drm_v5.7.19_1
+GH_TAGNAME=	drm_v5.7.19_2
 
 .include <bsd.port.options.mk>
 

--- a/graphics/drm-devel-kmod/Makefile
+++ b/graphics/drm-devel-kmod/Makefile
@@ -1,7 +1,7 @@
 # Created by: Johannes Dieterich <jmd@FreeBSD.org>
 
 PORTNAME=	drm-devel-kmod
-PORTVERSION=	5.7.19.g20220213
+PORTVERSION=	5.7.19.g20220223
 CATEGORIES=	graphics kld
 
 MAINTAINER=	x11@FreeBSD.org
@@ -24,7 +24,7 @@ USES=		kmod uidfix compiler:c++11-lang
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	drm-kmod
-GH_TAGNAME=	drm_v5.7.19_2
+GH_TAGNAME=	drm_v5.7.19_3
 
 .include <bsd.port.options.mk>
 

--- a/graphics/drm-devel-kmod/Makefile
+++ b/graphics/drm-devel-kmod/Makefile
@@ -1,7 +1,7 @@
 # Created by: Johannes Dieterich <jmd@FreeBSD.org>
 
 PORTNAME=	drm-devel-kmod
-PORTVERSION=	5.7.19.g20220126
+PORTVERSION=	5.7.19.g20220202
 CATEGORIES=	graphics kld
 
 MAINTAINER=	x11@FreeBSD.org
@@ -24,7 +24,7 @@ USES=		kmod uidfix compiler:c++11-lang
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	drm-kmod
-GH_TAGNAME=	drm_v5.7.19
+GH_TAGNAME=	drm_v5.7.19_1
 
 .include <bsd.port.options.mk>
 

--- a/graphics/drm-devel-kmod/distinfo
+++ b/graphics/drm-devel-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1640810482
-SHA256 (freebsd-drm-kmod-5.5.19.g20211230-drm_v5.5.19_7_GH0.tar.gz) = cc92e6c550992da530bddfb7533bd534fd312bcfb08aeb00c545b413bce4f43b
-SIZE (freebsd-drm-kmod-5.5.19.g20211230-drm_v5.5.19_7_GH0.tar.gz) = 18891766
+TIMESTAMP = 1643219771
+SHA256 (freebsd-drm-kmod-5.7.19.g20220126-drm_v5.7.19_GH0.tar.gz) = a290d33a550ca25a8af0c935f69f7b69ddbe903b2bdc7df4bc8d1a9b2b83bd3c
+SIZE (freebsd-drm-kmod-5.7.19.g20220126-drm_v5.7.19_GH0.tar.gz) = 18759497

--- a/graphics/drm-devel-kmod/distinfo
+++ b/graphics/drm-devel-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1644784701
-SHA256 (freebsd-drm-kmod-5.7.19.g20220213-drm_v5.7.19_2_GH0.tar.gz) = d2b80845f92a93a3949d31d7db252aa121fc3b5fe9973043ab49c8277a432a90
-SIZE (freebsd-drm-kmod-5.7.19.g20220213-drm_v5.7.19_2_GH0.tar.gz) = 18760584
+TIMESTAMP = 1645621031
+SHA256 (freebsd-drm-kmod-5.7.19.g20220223-drm_v5.7.19_3_GH0.tar.gz) = 3166d625e2ffea89fe93ad5d9d9a2c8b6139700b34acde119ba980528ec1619a
+SIZE (freebsd-drm-kmod-5.7.19.g20220223-drm_v5.7.19_3_GH0.tar.gz) = 18760694

--- a/graphics/drm-devel-kmod/distinfo
+++ b/graphics/drm-devel-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1643219771
-SHA256 (freebsd-drm-kmod-5.7.19.g20220126-drm_v5.7.19_GH0.tar.gz) = a290d33a550ca25a8af0c935f69f7b69ddbe903b2bdc7df4bc8d1a9b2b83bd3c
-SIZE (freebsd-drm-kmod-5.7.19.g20220126-drm_v5.7.19_GH0.tar.gz) = 18759497
+TIMESTAMP = 1643817453
+SHA256 (freebsd-drm-kmod-5.7.19.g20220202-drm_v5.7.19_1_GH0.tar.gz) = 075ab24f27c0d3b5f0b27a86d458337657ad1080b446a9e808d31ce967a48ed5
+SIZE (freebsd-drm-kmod-5.7.19.g20220202-drm_v5.7.19_1_GH0.tar.gz) = 18760066

--- a/graphics/drm-devel-kmod/distinfo
+++ b/graphics/drm-devel-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1643817453
-SHA256 (freebsd-drm-kmod-5.7.19.g20220202-drm_v5.7.19_1_GH0.tar.gz) = 075ab24f27c0d3b5f0b27a86d458337657ad1080b446a9e808d31ce967a48ed5
-SIZE (freebsd-drm-kmod-5.7.19.g20220202-drm_v5.7.19_1_GH0.tar.gz) = 18760066
+TIMESTAMP = 1644784701
+SHA256 (freebsd-drm-kmod-5.7.19.g20220213-drm_v5.7.19_2_GH0.tar.gz) = d2b80845f92a93a3949d31d7db252aa121fc3b5fe9973043ab49c8277a432a90
+SIZE (freebsd-drm-kmod-5.7.19.g20220213-drm_v5.7.19_2_GH0.tar.gz) = 18760584

--- a/graphics/drm-fbsd13-kmod/Makefile
+++ b/graphics/drm-fbsd13-kmod/Makefile
@@ -1,7 +1,7 @@
 # Created by: Johannes Dieterich <jmd@FreeBSD.org>
 
 PORTNAME=	drm-fbsd13-kmod
-PORTVERSION=	5.4.144.g20220128
+PORTVERSION=	5.4.144.g20220223
 CATEGORIES=	graphics kld
 
 MAINTAINER=	x11@FreeBSD.org
@@ -26,7 +26,7 @@ USES=		kmod uidfix compiler:c++11-lang
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd
 GH_PROJECT=	drm-kmod
-GH_TAGNAME=	drm_v5.4.144_5
+GH_TAGNAME=	drm_v5.4.144_6
 
 .include <bsd.port.options.mk>
 

--- a/graphics/drm-fbsd13-kmod/distinfo
+++ b/graphics/drm-fbsd13-kmod/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1643364117
-SHA256 (freebsd-drm-kmod-5.4.144.g20220128-drm_v5.4.144_5_GH0.tar.gz) = 43733caa354ee7fd01848ca3a91597f9dc0795f0b0aa2e29d07f23b27dcd5a87
-SIZE (freebsd-drm-kmod-5.4.144.g20220128-drm_v5.4.144_5_GH0.tar.gz) = 18822689
+TIMESTAMP = 1645628224
+SHA256 (freebsd-drm-kmod-5.4.144.g20220223-drm_v5.4.144_6_GH0.tar.gz) = a3c9aa4ebbdc5f40ac0ac4a4b51736d788d0a50428a0ae39a251975c9cb5aca8
+SIZE (freebsd-drm-kmod-5.4.144.g20220223-drm_v5.4.144_6_GH0.tar.gz) = 18822252


### PR DESCRIPTION
cherry-pick several commits from upstream freebsd-ports/ports to address build failure.