### PR TITLE
NAS-118566 / 13.0 / net/netatalk3 - additional regression fixes

### DIFF
--- a/net/netatalk3/Makefile
+++ b/net/netatalk3/Makefile
@@ -22,6 +22,7 @@ USE_LDCONFIG=	yes
 USE_RC_SUBR=	netatalk
 CPE_VENDOR=	netatalk_project
 EXTRA_PATCHES+=	${PATCHDIR}/fix-v3.1.13-issues.patch:-p1
+EXTRA_PATCHES+=	${PATCHDIR}/Fix-CVE-2022-23121-CVE-2022-23123-regression.patch:-p1
 
 CONFIGURE_ARGS+=	--with-pkgconfdir=${PREFIX}/etc \
 			--with-libgcrypt-dir=${LOCALBASE} \

--- a/net/netatalk3/files/Fix-CVE-2022-23121-CVE-2022-23123-regression.patch
+++ b/net/netatalk3/files/Fix-CVE-2022-23121-CVE-2022-23123-regression.patch
@@ -1,0 +1,491 @@
+From f1c6e580a1e8851f1a7aae95c40ebb01c6337cb1 Mon Sep 17 00:00:00 2001
+From: andychen <andychen@synology.com>
+Date: Wed, 6 Apr 2022 20:10:03 +0800
+Subject: [PATCH] Fix CVE-2022-23121, CVE-2022-23123 regression
+
+- Added guard check before access ad_entry()
+- Allow zero length entry, for AppleDouble specification
+---
+ etc/afpd/desktop.c          |  4 +--
+ etc/afpd/directory.c        |  9 ++---
+ etc/afpd/extattrs.c         |  3 +-
+ etc/afpd/file.c             | 25 ++++++--------
+ etc/afpd/volume.c           |  5 +--
+ libatalk/adouble/ad_attr.c  | 67 ++++++++++++++++++++++---------------
+ libatalk/adouble/ad_date.c  |  4 +--
+ libatalk/adouble/ad_flush.c | 38 +++++++++++++--------
+ libatalk/adouble/ad_open.c  | 30 ++++++++++++-----
+ 9 files changed, 105 insertions(+), 80 deletions(-)
+
+diff --git a/etc/afpd/desktop.c b/etc/afpd/desktop.c
+index 5c56977a..c259cad2 100644
+--- a/etc/afpd/desktop.c
++++ b/etc/afpd/desktop.c
+@@ -859,7 +859,7 @@ static int ad_addcomment(const AFPObj *obj, struct vol *vol, struct path *path,
+         return( AFPERR_ACCESS );
+     }
+ 
+-    if (ad_getentryoff(adp, ADEID_COMMENT)) {
++    if (ad_getentryoff(adp, ADEID_COMMENT) && ad_entry(adp, ADEID_COMMENT)) {
+         if ( (ad_get_MD_flags( adp ) & O_CREAT) ) {
+             if ( *path->m_name == '\0' ) {
+                 name = (char *)curdir->d_m_name->data;
+@@ -932,7 +932,7 @@ static int ad_getcomment(struct vol *vol, struct path *path, char *rbuf, size_t
+         return( AFPERR_NOITEM );
+     }
+ 
+-    if (!ad_getentryoff(adp, ADEID_COMMENT)) {
++    if (!ad_getentryoff(adp, ADEID_COMMENT) || !ad_entry(adp, ADEID_COMMENT)) {
+         ad_close(adp, ADFLAGS_HF);
+         return AFPERR_NOITEM;
+     }
+diff --git a/etc/afpd/directory.c b/etc/afpd/directory.c
+index d53ce1e1..a4c97403 100644
+--- a/etc/afpd/directory.c
++++ b/etc/afpd/directory.c
+@@ -1520,10 +1520,7 @@ int getdirparams(const AFPObj *obj,
+             break;
+ 
+         case DIRPBIT_FINFO :
+-            if ( isad ) {
+-                ade = ad_entry(&ad, ADEID_FINDERI);
+-                AFP_ASSERT(ade != NULL);
+-
++            if ( isad && (ade = ad_entry(&ad, ADEID_FINDERI)) != NULL) {
+                 memcpy( data, ade, 32 );
+             } else { /* no appledouble */
+                 memset( data, 0, 32 );
+@@ -1903,15 +1900,13 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap, char *bu
+             }
+             break;
+         case DIRPBIT_FINFO :
+-            if (isad) {
++            if (isad && (ade = ad_entry(&ad, ADEID_FINDERI)) != NULL) {
+                 /* Fixes #2802236 */
+                 uint16_t fflags;
+                 memcpy(&fflags, finder_buf + FINDERINFO_FRFLAGOFF, sizeof(uint16_t));
+                 fflags &= htons(~FINDERINFO_ISHARED);
+                 memcpy(finder_buf + FINDERINFO_FRFLAGOFF, &fflags, sizeof(uint16_t));
+                 /* #2802236 end */
+-                ade = ad_entry(&ad, ADEID_FINDERI);
+-                AFP_ASSERT(ade != NULL);
+ 
+                 if (  dir->d_did == DIRDID_ROOT ) {
+                     /*
+diff --git a/etc/afpd/extattrs.c b/etc/afpd/extattrs.c
+index b0f1bed6..77c7b193 100644
+--- a/etc/afpd/extattrs.c
++++ b/etc/afpd/extattrs.c
+@@ -146,6 +146,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
+ 
+     adp = &ad;
+     ad_init(adp, vol);
++    ad_init_offsets(adp);
+ 
+     if (path_isadir(s_path)) {
+ 	    LOG(log_debug, logtype_afpd, "afp_listextattr(%s): is a dir", uname);
+@@ -175,7 +176,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
+         close_ad = true;
+         FinderInfo = ad_entry(adp, ADEID_FINDERI);
+         /* Check if FinderInfo equals default and empty FinderInfo*/
+-        if (memcmp(FinderInfo, emptyFinderInfo, 32) != 0) {
++        if (FinderInfo && memcmp(FinderInfo, emptyFinderInfo, 32) != 0) {
+             /* FinderInfo contains some non 0 bytes -> include "com.apple.FinderInfo" */
+             strcpy(attrnamebuf, ea_finderinfo);
+             attrbuflen += strlen(ea_finderinfo) + 1;
+diff --git a/etc/afpd/file.c b/etc/afpd/file.c
+index 0b6c94ed..ab181994 100644
+--- a/etc/afpd/file.c
++++ b/etc/afpd/file.c
+@@ -497,10 +497,7 @@ int getmetadata(const AFPObj *obj,
+                 data += sizeof( aint );
+             }
+             else {
+-                if ( adp ) {
+-                    ade = ad_entry(adp, ADEID_FINDERI);
+-                    AFP_ASSERT(ade != NULL);
+-
++                if ( adp && (ade = ad_entry(adp, ADEID_FINDERI)) != NULL) {
+                     memcpy(fdType, ade, 4);
+ 
+                     if ( memcmp( fdType, "TEXT", 4 ) == 0 ) {
+@@ -588,10 +585,8 @@ int getmetadata(const AFPObj *obj,
+              * improper ops on symlink adoubles will be
+              * more visible (assert).
+              */
+-            if (adp && (ad_meta_fileno(adp) != AD_SYMLINK)) {
+-                ade = ad_entry(adp, ADEID_FINDERI);
+-                AFP_ASSERT(ade != NULL);
+-
++            if (adp && (ad_meta_fileno(adp) != AD_SYMLINK)
++                && (ade = ad_entry(adp, ADEID_FINDERI)) != NULL) {
+ 	        memcpy(fdType, ade, 4);
+                 if ( memcmp( fdType, "slnk", 4 ) == 0 ) {
+ 	 	    aint |= S_IFLNK;
+@@ -1071,7 +1066,10 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
+                 break;
+             }
+             ade = ad_entry(adp, ADEID_FINDERI);
+-            AFP_ASSERT(ade != NULL);
++            if (ade == NULL) {
++                LOG(log_debug, logtype_afpd, "setfilparams(\"%s\"): invalid FinderInfo", path->u_name);
++                break;
++            }
+             if (default_type(ade)
+                     && ( 
+                      ((em = getextmap( path->m_name )) &&
+@@ -1094,12 +1092,11 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
+             if (isad == 0) {
+                 break;
+             }
+-            ade = ad_entry(adp, ADEID_FINDERI);
+-            AFP_ASSERT(ade != NULL);
+-
+             if (obj->afp_version < 30) { /* else it's UTF8 name */
+-                memcpy(ade, fdType, 4 );
+-                memcpy(ade + 4, "pdos", 4 );
++                if ((ade = ad_entry(adp, ADEID_FINDERI)) != NULL) {
++                    memcpy(ade, fdType, 4 );
++                    memcpy(ade + 4, "pdos", 4 );
++                }
+                 break;
+             }
+             /* fallthrough */
+diff --git a/etc/afpd/volume.c b/etc/afpd/volume.c
+index 06a56c16..a98febd5 100644
+--- a/etc/afpd/volume.c
++++ b/etc/afpd/volume.c
+@@ -330,11 +330,8 @@ static int getvolparams(const AFPObj *obj, uint16_t bitmap, struct vol *vol, str
+             slash++;
+         else
+             slash = vol->v_path;
+-        if (ad_getentryoff(&ad, ADEID_NAME)) {
++        if (ad_getentryoff(&ad, ADEID_NAME) && (ade = ad_entry(&ad, ADEID_NAME)) != NULL) {
+             ad_setentrylen( &ad, ADEID_NAME, strlen( slash ));
+-            ade = ad_entry(&ad, ADEID_NAME);
+-            AFP_ASSERT(ade != NULL);
+-
+             memcpy(ade, slash, ad_getentrylen( &ad, ADEID_NAME ));
+         }
+         vol_setdate(vol->v_vid, &ad, st->st_mtime);
+diff --git a/libatalk/adouble/ad_attr.c b/libatalk/adouble/ad_attr.c
+index 7130e213..207779d9 100644
+--- a/libatalk/adouble/ad_attr.c
++++ b/libatalk/adouble/ad_attr.c
+@@ -8,6 +8,7 @@
+ #include <atalk/util.h>
+ #include <atalk/adouble.h>
+ #include <atalk/logger.h>
++#include <atalk/errchk.h>
+ 
+ #define FILEIOFF_ATTR 14
+ #define AFPFILEIOFF_ATTR 2
+@@ -21,20 +22,19 @@
+ int ad_getattr(const struct adouble *ad, uint16_t *attr)
+ {
+     uint16_t fflags;
++    char *adp = NULL;
+     *attr = 0;
+ 
+-    if (ad_getentryoff(ad, ADEID_AFPFILEI)) {
+-        char *adp = NULL;
+-
+-        adp = ad_entry(ad, ADEID_AFPFILEI);
+-        AFP_ASSERT(adp != NULL);
++    if (ad_getentryoff(ad, ADEID_AFPFILEI) && (adp = ad_entry(ad, ADEID_AFPFILEI)) != NULL) {
+         memcpy(attr, adp + AFPFILEIOFF_ATTR, 2);
+ 
+         /* Now get opaque flags from FinderInfo */
+-        adp = ad_entry(ad, ADEID_FINDERI);
+-        AFP_ASSERT(adp != NULL);
+-        memcpy(&fflags, adp + FINDERINFO_FRFLAGOFF, 2);
+-
++        if ((adp = ad_entry(ad, ADEID_FINDERI)) != NULL) {
++            memcpy(&fflags, adp + FINDERINFO_FRFLAGOFF, 2);
++        } else {
++            LOG(log_debug, logtype_default, "ad_getattr(%s): invalid FinderInfo", ad->ad_name);
++            memset(&fflags, 0, 2);
++        }
+         if (fflags & htons(FINDERINFO_INVISIBLE))
+             *attr |= htons(ATTRBIT_INVISIBLE);
+         else
+@@ -60,6 +60,7 @@ int ad_getattr(const struct adouble *ad, uint16_t *attr)
+ int ad_setattr(const struct adouble *ad, const uint16_t attribute)
+ {
+     uint16_t fflags;
++    char *ade = NULL, *adp = NULL;
+ 
+     /* we don't save open forks indicator */
+     uint16_t attr = attribute & ~htons(ATTRBIT_DOPEN | ATTRBIT_ROPEN);
+@@ -69,13 +70,9 @@ int ad_setattr(const struct adouble *ad, const uint16_t attribute)
+     if (ad->ad_adflags & ADFLAGS_DIR)
+         attr &= ~(ATTRBIT_MULTIUSER | ATTRBIT_NOWRITE | ATTRBIT_NOCOPY);
+ 
+-    if (ad_getentryoff(ad, ADEID_AFPFILEI) && ad_getentryoff(ad, ADEID_FINDERI)) {
+-        char *adp = NULL;
+-
+-        adp = ad_entry(ad, ADEID_FINDERI);
+-        AFP_ASSERT(adp != NULL);
+-
+-        memcpy(adp + AFPFILEIOFF_ATTR, &attr, sizeof(attr));
++    if (ad_getentryoff(ad, ADEID_AFPFILEI) && (ade = ad_entry(ad, ADEID_AFPFILEI)) != NULL
++        && ad_getentryoff(ad, ADEID_FINDERI) && (adp = ad_entry(ad, ADEID_FINDERI)) != NULL) {
++        memcpy(ade + AFPFILEIOFF_ATTR, &attr, sizeof(attr));
+             
+         /* Now set opaque flags in FinderInfo too */
+         memcpy(&fflags, adp + FINDERINFO_FRFLAGOFF, 2);
+@@ -104,9 +101,12 @@ int ad_setattr(const struct adouble *ad, const uint16_t attribute)
+  */
+ int ad_setid (struct adouble *adp, const dev_t dev, const ino_t ino , const uint32_t id, const cnid_t did, const void *stamp)
+ {
++    EC_INIT;
+     uint32_t tmp;
+     char *ade = NULL;
++    ssize_t id_len = -1, dev_len = -1, ino_len = -1, did_len = -1, syn_len = -1;
+ 
++    id_len = ad_getentrylen(adp, ADEID_PRIVID);
+     ad_setentrylen( adp, ADEID_PRIVID, sizeof(id));
+     tmp = id;
+     if (adp->ad_vers == AD_VERSION_EA)
+@@ -114,16 +114,17 @@ int ad_setid (struct adouble *adp, const dev_t dev, const ino_t ino , const uint
+ 
+     ade = ad_entry(adp, ADEID_PRIVID);
+     if (ade == NULL) {
+-        LOG(log_warning, logtype_ad, "ad_setid: failed to set ADEID_PRIVID\n");
+-        return -1;
++        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVID", adp->ad_name);
++        EC_FAIL;
+     }
+     memcpy(ade, &tmp, sizeof(tmp));
+ 
++    dev_len = ad_getentrylen(adp, ADEID_PRIVDEV);
+     ad_setentrylen( adp, ADEID_PRIVDEV, sizeof(dev_t));
+     ade = ad_entry(adp, ADEID_PRIVDEV);
+     if (ade == NULL) {
+-        LOG(log_warning, logtype_ad, "ad_setid: failed to set ADEID_PRIVDEV\n");
+-        return -1;
++        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVDEV", adp->ad_name);
++        EC_FAIL;
+     }
+ 
+     if ((adp->ad_options & ADVOL_NODEV)) {
+@@ -132,34 +133,46 @@ int ad_setid (struct adouble *adp, const dev_t dev, const ino_t ino , const uint
+         memcpy(ade, &dev, sizeof(dev_t));
+     }
+ 
++    ino_len = ad_getentrylen(adp, ADEID_PRIVINO);
+     ad_setentrylen( adp, ADEID_PRIVINO, sizeof(ino_t));
+-
+     ade = ad_entry(adp, ADEID_PRIVINO);
+     if (ade == NULL) {
+-        LOG(log_warning, logtype_ad, "ad_setid: failed to set ADEID_PRIVINO\n");
+-        return -1;
++        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVINO", adp->ad_name);
++        EC_FAIL;
+     }
+     memcpy(ade, &ino, sizeof(ino_t));
+ 
+     if (adp->ad_vers != AD_VERSION_EA) {
++        did_len = ad_getentrylen(adp, ADEID_DID);
+         ad_setentrylen( adp, ADEID_DID, sizeof(did));
+ 
+         ade = ad_entry(adp, ADEID_DID);
+         if (ade == NULL) {
+-            LOG(log_warning, logtype_ad, "ad_setid: failed to set ADEID_DID\n");
+-            return -1;
++            LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_DID", adp->ad_name);
++            EC_FAIL;
+         }
+         memcpy(ade, &did, sizeof(did));
+     }
+ 
++    syn_len = ad_getentrylen(adp, ADEID_PRIVSYN);
+     ad_setentrylen( adp, ADEID_PRIVSYN, ADEDLEN_PRIVSYN);
+     ade = ad_entry(adp, ADEID_PRIVSYN);
+     if (ade == NULL) {
+-        LOG(log_warning, logtype_ad, "ad_setid: failed to set ADEID_PRIVSYN\n");
+-        return -1;
++        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVSYN", adp->ad_name);
++        EC_FAIL;
+     }
+     memcpy(ade, stamp, ADEDLEN_PRIVSYN);
+ 
++EC_CLEANUP:
++    if (ret != 0) {
++        if (id_len != -1) ad_setentrylen( adp, ADEID_PRIVID, id_len);
++        if (dev_len != -1) ad_setentrylen( adp, ADEID_PRIVDEV, dev_len);
++        if (ino_len != -1) ad_setentrylen( adp, ADEID_PRIVINO, ino_len);
++        if (did_len != -1) ad_setentrylen( adp, ADEID_DID, did_len);
++        if (syn_len != -1) ad_setentrylen( adp, ADEID_PRIVSYN, syn_len);
++        return 0;
++    }
++
+     return 1;
+ }
+ 
+diff --git a/libatalk/adouble/ad_date.c b/libatalk/adouble/ad_date.c
+index 30302908..182dd944 100644
+--- a/libatalk/adouble/ad_date.c
++++ b/libatalk/adouble/ad_date.c
+@@ -16,7 +16,7 @@ int ad_setdate(struct adouble *ad,
+     if (xlate)
+         date = AD_DATE_FROM_UNIX(date);
+ 
+-    if (!ad_getentryoff(ad, ADEID_FILEDATESI))
++    if (!ad_getentryoff(ad, ADEID_FILEDATESI) || !ad_entry(ad, ADEID_FILEDATESI))
+         return -1;
+ 
+     if (dateoff > AD_DATE_ACCESS)
+@@ -38,7 +38,7 @@ int ad_getdate(const struct adouble *ad,
+     char *ade = NULL;
+ 
+     dateoff &= AD_DATE_MASK;
+-    if (!ad_getentryoff(ad, ADEID_FILEDATESI))
++    if (!ad_getentryoff(ad, ADEID_FILEDATESI) || !ad_entry(ad, ADEID_FILEDATESI))
+         return -1;
+ 
+     if (dateoff > AD_DATE_ACCESS)
+diff --git a/libatalk/adouble/ad_flush.c b/libatalk/adouble/ad_flush.c
+index 2f8aa726..aa9a68d9 100644
+--- a/libatalk/adouble/ad_flush.c
++++ b/libatalk/adouble/ad_flush.c
+@@ -187,9 +187,11 @@ int ad_rebuild_adouble_header_osx(struct adouble *ad, char *adbuf)
+     buf += sizeof( temp );
+ 
+     ade = ad_entry(ad, ADEID_FINDERI);
+-    AFP_ASSERT(ade != NULL);
+-
+-    memcpy(adbuf + ADEDOFF_FINDERI_OSX, ade, ADEDLEN_FINDERI);
++    if (ade != NULL) {
++        memcpy(adbuf + ADEDOFF_FINDERI_OSX, ade, ADEDLEN_FINDERI);
++    } else {
++        LOG(log_debug, logtype_ad, "ad_rebuild_adouble_header_osx(%s): invalid FinderInfo", ad->ad_name);
++    }
+ 
+     /* rfork */
+     temp = htonl( EID_DISK(ADEID_RFORK) );
+@@ -219,6 +221,10 @@ int ad_copy_header(struct adouble *add, struct adouble *ads)
+     char *src = NULL;
+     char *dst = NULL;
+ 
++    if (add->valid_data_len == 0) {
++        LOG(log_error, logtype_ad, "ad_copy_header(%s): dst invalid valid_data_len", add->ad_name);
++        return -1;
++    }
+     for ( eid = 0; eid < ADEID_MAX; eid++ ) {
+         src = dst = NULL;
+ 
+@@ -234,13 +240,15 @@ int ad_copy_header(struct adouble *add, struct adouble *ads)
+         case ADEID_RFORK:
+             continue;
+         default:
++            if ((src = ad_entry(ads, eid)) == NULL) {
++                LOG(log_debug, logtype_ad, "ad_copy_header(%s): invalid src eid[%d]", ads->ad_name, eid);
++                continue;
++            }
++            if ((dst = ad_entry(add, eid)) == NULL) {
++                LOG(log_debug, logtype_ad, "ad_copy_header(%s): invalid dst eid[%d]", add->ad_name, eid);
++                continue;
++            }
+             ad_setentrylen( add, eid, len );
+-            dst = ad_entry(add, eid);
+-            AFP_ASSERT(dst != NULL);
+-
+-            src = ad_entry(ads, eid);
+-            AFP_ASSERT(src != NULL);
+-
+             memcpy( dst, src, len );
+         }
+     }
+@@ -252,11 +260,13 @@ int ad_copy_header(struct adouble *add, struct adouble *ads)
+         cnid_t id;
+ 
+         dst = ad_entry(add, ADEID_PRIVID);
+-        AFP_ASSERT(dst != NULL);
+-
+-        memcpy(&id, dst, sizeof(cnid_t));
+-        id = htonl(id);
+-        memcpy(dst, &id, sizeof(cnid_t));
++        if (dst != NULL) {
++            memcpy(&id, dst, sizeof(cnid_t));
++            id = htonl(id);
++            memcpy(dst, &id, sizeof(cnid_t));
++        } else {
++            LOG(log_debug, logtype_ad, "ad_copy_header(%s): invalid PRIVID", add->ad_name);
++        }
+     }
+     return 0;
+ }
+diff --git a/libatalk/adouble/ad_open.c b/libatalk/adouble/ad_open.c
+index bfe7b5b7..e5c70cf7 100644
+--- a/libatalk/adouble/ad_open.c
++++ b/libatalk/adouble/ad_open.c
+@@ -358,11 +358,13 @@ int ad_init_offsets(struct adouble *ad)
+ 
+     memset(ad->ad_data, 0, sizeof(ad->ad_data));
+ 
+-    if (ad->ad_vers == AD_VERSION2)
++    if (ad->ad_vers == AD_VERSION2) {
+         eid = entry_order2;
+-    else if (ad->ad_vers == AD_VERSION_EA)
++        ad->valid_data_len = AD_DATASZ2;
++    } else if (ad->ad_vers == AD_VERSION_EA) {
+         eid = entry_order_ea;
+-    else
++        ad->valid_data_len = AD_DATASZ_EA;
++    } else
+         return -1;
+ 
+     while (eid->id) {
+@@ -399,8 +401,10 @@ static int new_ad_header(struct adouble *ad, const char *path, struct stat *stp,
+         ad->valid_data_len = ad->ad_vers == AD_VERSION_EA ? AD_DATASZ_EA : AD_DATASZ2;
+     }
+     adp = ad_entry(ad, ADEID_FINDERI);
+-    AFP_ASSERT(adp != NULL);
+-
++    if (adp == NULL) {
++        LOG(log_debug, logtype_ad, "new_ad_header(\"%s\"): invalid FinderInfo", path);
++        return -1;
++    }
+     /* set default creator/type fields */
+     memcpy(adp + FINDERINFO_FRTYPEOFF,"\0\0\0\0", 4);
+     memcpy(adp + FINDERINFO_FRCREATOFF,"\0\0\0\0", 4);
+@@ -454,7 +458,7 @@ static int parse_entries(struct adouble *ad, uint16_t nentries, size_t valid_dat
+ 
+         if (!eid
+             || eid > ADEID_MAX
+-            || ((eid != ADEID_RFORK) && (off >= valid_data_len))
++            || ((eid != ADEID_RFORK) && (off > valid_data_len))
+             || ((eid != ADEID_RFORK) && (off + len >  valid_data_len)))
+         {
+             LOG(log_warning, logtype_ad, "parse_entries: bogus eid: %u, off: %u, len: %u",
+@@ -652,15 +656,23 @@ static int ad_convert_osx(const char *path, struct adouble *ad)
+         EC_EXIT_STATUS(0);
+     struct adouble adea;
+     ad_init_old(&adea, AD_VERSION_EA, ad->ad_options);
++    if (ad_init_offsets(&adea) != 0) {
++        LOG(log_error, logtype_ad, "ad_init_offsets failed");
++        EC_FAIL;
++    }
+ 
+     if (ad_open(&adea, path + 2, ADFLAGS_HF | ADFLAGS_RDWR | ADFLAGS_CREATE, 0666) < 0) {
+         LOG(log_error, logtype_ad, "create metadata: %s\n", strerror(errno));
+         EC_FAIL;
+     }
+     if (adea.ad_mdp->adf_flags & O_CREAT) {
+-        memcpy(ad_entry(&adea, ADEID_FINDERI),
+-               ad_entry(ad, ADEID_FINDERI),
+-               ADEDLEN_FINDERI);
++        if (ad_entry(ad, ADEID_FINDERI)) {
++            memcpy(ad_entry(&adea, ADEID_FINDERI),
++                   ad_entry(ad, ADEID_FINDERI),
++                   ADEDLEN_FINDERI);
++        } else {
++            LOG(log_debug, logtype_ad, "ad_convert_osx(%s): invalid FinderInfo", fullpathname(path));
++        }
+         ad_flush(&adea);
+     }
+     ad_close(&adea, ADFLAGS_HF);
+-- 
+2.21.0 (Apple Git-122)
+


### PR DESCRIPTION
- Added guard check before access ad_entry()
- Allow zero length entry, for AppleDouble specification