### PR TITLE
math/py-numpy: avoid using os.sched_getaffinity

### DIFF
--- a/math/py-numpy/files/patch-numpy_distutils_misc__util.py
+++ b/math/py-numpy/files/patch-numpy_distutils_misc__util.py
@@ -1,0 +1,14 @@
+--- numpy/distutils/misc_util.py.orig	2023-05-03 12:50:14 UTC
++++ numpy/distutils/misc_util.py
+@@ -89,10 +89,7 @@ def get_num_build_jobs():
+ 
+     """
+     from numpy.distutils.core import get_distribution
+-    try:
+-        cpu_count = len(os.sched_getaffinity(0))
+-    except AttributeError:
+-        cpu_count = multiprocessing.cpu_count()
++    cpu_count = multiprocessing.cpu_count()
+     cpu_count = min(cpu_count, 8)
+     envjobs = int(os.environ.get("NPY_NUM_BUILD_JOBS", cpu_count))
+     dist = get_distribution()


### PR DESCRIPTION
It will raise an OverflowError for unknown reason. Possibly due to host running 13.1 and jail running 13.2.