### PR TITLE
NAS-125590 / 13.1 / Use uucp user for nut port instead of nut user

### DIFF
--- a/sysutils/nut/Makefile
+++ b/sysutils/nut/Makefile
@@ -18,8 +18,8 @@ GNU_CONFIGURE=	yes
 USES=		autoreconf:build compiler:c11 gmake libtool pkgconfig python:build
 USE_LDCONFIG=	yes
 
-NUT_USER?=	nut
-NUT_GROUP?=	nut
+NUT_USER?=	uucp
+NUT_GROUP?=	uucp
 USERS=		${NUT_USER}
 GROUPS=		${NUT_GROUP} dialer
 STATEDIR?=	/var/db/nut

--- a/sysutils/nut/Makefile
+++ b/sysutils/nut/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	nut
 PORTVERSION=	2.8.0
-PORTREVISION=	23
+PORTREVISION=	24
 CATEGORIES=	sysutils
 MASTER_SITES=	http://www.networkupstools.org/source/${PORTVERSION:R}/
 

--- a/sysutils/nut/files/nut.newsyslog
+++ b/sysutils/nut/files/nut.newsyslog
@@ -3,5 +3,5 @@
 # see newsyslog.conf(5) for details
 #
 # logfilename          [owner:group]    mode    count   size    when    flags   [/pid_file]     	[sig_num]
-/var/log/nut/upsd.log   nut:nut       644     7       100     *       J       /var/db/nut/upslog.pid
+/var/log/nut/upsd.log   uucp:uucp       644     7       100     *       J       /var/db/nut/upslog.pid
 


### PR DESCRIPTION
## Problem

In CORE 13.1, the user being used for upsmon service has been changed from `uucp` to `nut`. This alteration in the username is causing the Nut UPS service to crash.

## Solution

Nut port has been changed to keep on using `uucp` user to avoid adding another user to our CORE image.