### PR TITLE
NAS-127917 / 13.3 / Remove py-beaker dependency from textproc/mako

### DIFF
--- a/textproc/py-mako/Makefile
+++ b/textproc/py-mako/Makefile
@@ -11,11 +11,9 @@ WWW=		https://www.makotemplates.org/
 
 LICENSE=	MIT
 
-BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}beaker>=1.1:www/py-beaker@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}markupsafe>=0.9.2:textproc/py-markupsafe@${PY_FLAVOR} \
+BUILD_DEPENDS= ${PYTHON_PKGNAMEPREFIX}markupsafe>=0.9.2:textproc/py-markupsafe@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}Babel>0:devel/py-babel@${PY_FLAVOR}
-RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}beaker>=1.1:www/py-beaker@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}markupsafe>=0.9.2:textproc/py-markupsafe@${PY_FLAVOR} \
+RUN_DEPENDS=   ${PYTHON_PKGNAMEPREFIX}markupsafe>=0.9.2:textproc/py-markupsafe@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}Babel>0:devel/py-babel@${PY_FLAVOR}
 
 USES=		python


### PR DESCRIPTION
This is neither a build nor a runtime dependeny of mako. Allow building without py-beaker due to said library being subject to an unresolved CVE for almost a year. TrueNAS does not use the beaker cache in mako and so has never been vulnerable to exploiting this CVE.