### PR TITLE
NAS-127932 / 13.3 / net/samba - fix wsdd dependency

### DIFF
--- a/net/samba/Makefile
+++ b/net/samba/Makefile
@@ -334,6 +334,7 @@ SAMBA4_BUNDLED_LIBS+=		!pyldb,!pyldb-util
 # External Python modules
 BUILD_DEPENDS+=			${PYTHON_PKGNAMEPREFIX}dnspython>=1.15.0:dns/py-dnspython@${PY_FLAVOR}
 RUN_DEPENDS+=			${PYTHON_PKGNAMEPREFIX}dnspython>=1.15.0:dns/py-dnspython@${PY_FLAVOR}
+RUN_DEPENDS+=			${PYTHON_PKGNAMEPREFIX}defusedxml>=0:devel/py-defusedxml@${PY_FLAVOR}
 
 BUILD_DEPENDS+=			${PYTHON_PKGNAMEPREFIX}iso8601>=0.1.11:devel/py-iso8601@${PY_FLAVOR}
 .endif


### PR DESCRIPTION
wsdd, which is included in samba port, now depends on defusedxml. Properly mark this as a runtime dependency.