### PR TITLE
NAS-124036 / 13.3 / Update net/rsync to 3.2.7

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -1,7 +1,7 @@
 # Created by: David O'Brien (obrien@cs.ucdavis.edu)
 
 PORTNAME=	rsync
-DISTVERSION=	3.2.6
+DISTVERSION=	3.2.7
 CATEGORIES=	net
 MASTER_SITES=	https://www.mirrorservice.org/sites/rsync.samba.org/src/ \
 		http://rsync.mirror.garr.it/src/ \
@@ -21,7 +21,7 @@ LIB_DEPENDS=	liblz4.so:archivers/liblz4 \
 		libxxhash.so:devel/xxhash \
 		libzstd.so:archivers/zstd
 
-USES=		cpe python shebangfix ssl
+USES=		cpe python shebangfix ssl autoreconf
 PYTHON_NO_DEPENDS=	yes
 CPE_VENDOR=	samba
 CPE_PRODUCT=	rsync

--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -62,18 +62,15 @@ ZLIB_BASE_DESC=	Use zlib from base instead of bundled one
 PTS_DESC=	Functionality provided by third party patches
 RENAMED_DESC=	Add support for renamed file detection
 
-FLAGS_DISTFILES=	${PORTNAME}-patches-${DISTVERSION}${EXTRACT_SUFX}
 FLAGS_EXTRA_PATCHES=	${WRKSRC}/patches/fileflags.diff \
 			${FILESDIR}/extrapatch-main.c
 
-ICONV_DISTFILES=	${PORTNAME}-patches-${DISTVERSION}${EXTRACT_SUFX}
 ICONV_USES=		iconv:translit
 ICONV_CONFIGURE_ENABLE=	iconv iconv-open
 
 POPT_PORT_LIB_DEPENDS=		libpopt.so:devel/popt
 POPT_PORT_CONFIGURE_OFF=	--with-included-popt
 
-RENAMED_DISTFILES=	${PORTNAME}-patches-${DISTVERSION}${EXTRACT_SUFX}
 RENAMED_EXTRA_PATCHES=	${WRKSRC}/patches/detect-renamed.diff
 
 SSH_CONFIGURE_ON=	--with-rsh=ssh
@@ -83,7 +80,9 @@ ZLIB_BASE_CONFIGURE_ON=	--with-included-zlib=no
 
 ACL_EXTRA_PATCHES+=	${PATCHDIR}/fix-nfs4_acls.patch
 
-.if make(makesum)
+.include <bsd.port.options.mk>
+
+.if make(makesum) || ${PORT_OPTIONS:MRENAMED} || ${PORT_OPTIONS:MICONV} || ${PORT_OPTIONS:MRENAMED}
 DISTFILES+=	${PORTNAME}-patches-${DISTVERSION}${EXTRACT_SUFX}
 .endif
 

--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -21,7 +21,7 @@ LIB_DEPENDS=	liblz4.so:archivers/liblz4 \
 		libxxhash.so:devel/xxhash \
 		libzstd.so:archivers/zstd
 
-USES=		cpe python shebangfix ssl autoreconf
+USES=		cpe python shebangfix ssl
 PYTHON_NO_DEPENDS=	yes
 CPE_VENDOR=	samba
 CPE_PRODUCT=	rsync
@@ -62,15 +62,18 @@ ZLIB_BASE_DESC=	Use zlib from base instead of bundled one
 PTS_DESC=	Functionality provided by third party patches
 RENAMED_DESC=	Add support for renamed file detection
 
+FLAGS_DISTFILES=	${PORTNAME}-patches-${DISTVERSION}${EXTRACT_SUFX}
 FLAGS_EXTRA_PATCHES=	${WRKSRC}/patches/fileflags.diff \
 			${FILESDIR}/extrapatch-main.c
 
+ICONV_DISTFILES=	${PORTNAME}-patches-${DISTVERSION}${EXTRACT_SUFX}
 ICONV_USES=		iconv:translit
 ICONV_CONFIGURE_ENABLE=	iconv iconv-open
 
 POPT_PORT_LIB_DEPENDS=		libpopt.so:devel/popt
 POPT_PORT_CONFIGURE_OFF=	--with-included-popt
 
+RENAMED_DISTFILES=	${PORTNAME}-patches-${DISTVERSION}${EXTRACT_SUFX}
 RENAMED_EXTRA_PATCHES=	${WRKSRC}/patches/detect-renamed.diff
 
 SSH_CONFIGURE_ON=	--with-rsh=ssh

--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -1,7 +1,7 @@
 # Created by: David O'Brien (obrien@cs.ucdavis.edu)
 
 PORTNAME=	rsync
-DISTVERSION=	3.2.5
+DISTVERSION=	3.2.6
 CATEGORIES=	net
 MASTER_SITES=	https://www.mirrorservice.org/sites/rsync.samba.org/src/ \
 		http://rsync.mirror.garr.it/src/ \

--- a/net/rsync/distinfo
+++ b/net/rsync/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1666074411
-SHA256 (rsync-3.2.6.tar.gz) = fb3365bab27837d41feaf42e967c57bd3a47bc8f10765a3671efd6a3835454d3
-SIZE (rsync-3.2.6.tar.gz) = 1138593
-SHA256 (rsync-patches-3.2.6.tar.gz) = c3d13132b560f456fd8fc9fdf9f59377e91adf0dfc8117e33800d14b483d1a85
-SIZE (rsync-patches-3.2.6.tar.gz) = 148382
+TIMESTAMP = 1670705387
+SHA256 (rsync-3.2.7.tar.gz) = 4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb
+SIZE (rsync-3.2.7.tar.gz) = 1149787
+SHA256 (rsync-patches-3.2.7.tar.gz) = e7e5e9ea0b6dd7639c7a5c6f49a1d06be20d449d59f60ba59b238e1aa79b13f0
+SIZE (rsync-patches-3.2.7.tar.gz) = 99514

--- a/net/rsync/distinfo
+++ b/net/rsync/distinfo
@@ -3,7 +3,3 @@ SHA256 (rsync-3.2.6.tar.gz) = fb3365bab27837d41feaf42e967c57bd3a47bc8f10765a3671
 SIZE (rsync-3.2.6.tar.gz) = 1138593
 SHA256 (rsync-patches-3.2.6.tar.gz) = c3d13132b560f456fd8fc9fdf9f59377e91adf0dfc8117e33800d14b483d1a85
 SIZE (rsync-patches-3.2.6.tar.gz) = 148382
-SHA256 (rsync-patches-3.2.6.tar.gz) = c3d13132b560f456fd8fc9fdf9f59377e91adf0dfc8117e33800d14b483d1a85
-SIZE (rsync-patches-3.2.6.tar.gz) = 148382
-SHA256 (rsync-patches-3.2.6.tar.gz) = c3d13132b560f456fd8fc9fdf9f59377e91adf0dfc8117e33800d14b483d1a85
-SIZE (rsync-patches-3.2.6.tar.gz) = 148382

--- a/net/rsync/distinfo
+++ b/net/rsync/distinfo
@@ -1,5 +1,9 @@
-TIMESTAMP = 1660557599
-SHA256 (rsync-3.2.5.tar.gz) = 2ac4d21635cdf791867bc377c35ca6dda7f50d919a58be45057fd51600c69aba
-SIZE (rsync-3.2.5.tar.gz) = 1129957
-SHA256 (rsync-patches-3.2.5.tar.gz) = e7b1fdf1fc0fca68fd254246c2dc04f6ac90241e665dcf9dfc21dccd8270b6bb
-SIZE (rsync-patches-3.2.5.tar.gz) = 141521
+TIMESTAMP = 1666074411
+SHA256 (rsync-3.2.6.tar.gz) = fb3365bab27837d41feaf42e967c57bd3a47bc8f10765a3671efd6a3835454d3
+SIZE (rsync-3.2.6.tar.gz) = 1138593
+SHA256 (rsync-patches-3.2.6.tar.gz) = c3d13132b560f456fd8fc9fdf9f59377e91adf0dfc8117e33800d14b483d1a85
+SIZE (rsync-patches-3.2.6.tar.gz) = 148382
+SHA256 (rsync-patches-3.2.6.tar.gz) = c3d13132b560f456fd8fc9fdf9f59377e91adf0dfc8117e33800d14b483d1a85
+SIZE (rsync-patches-3.2.6.tar.gz) = 148382
+SHA256 (rsync-patches-3.2.6.tar.gz) = c3d13132b560f456fd8fc9fdf9f59377e91adf0dfc8117e33800d14b483d1a85
+SIZE (rsync-patches-3.2.6.tar.gz) = 148382


### PR DESCRIPTION
This brings in ports tree updates for rsync that were in truenas/13.0-stable but not truenas/13.1-stable.