### PR TITLE
sysutils/hptcli: Unbreak port

### DIFF
--- a/sysutils/hptcli/Makefile
+++ b/sysutils/hptcli/Makefile
@@ -4,7 +4,7 @@ PORTNAME=	hptcli
 PORTVERSION=	3.6
 PORTREVISION=	2
 CATEGORIES=	sysutils
-MASTER_SITES=	http://mirrors.infowest.com/freebsd-ftp/ports/distfiles/
+MASTER_SITES=	https://download.freenas.org/distfiles/
 DISTNAME=	CLI-FreeBSD-3.6-1-120913
 
 MAINTAINER=	wg@FreeBSD.org


### PR DESCRIPTION
Point MASTER_SITES to a new location

Reported by:	pkg-fallout
Approved by:	portmgr (blanket)

(cherry picked from commit 689320056d6db46f54059d951f8ca533b8d92c96)