### PR TITLE
NAS-133755 / 13.3-stable / Apply additional upstream fixes to net/rsync

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	rsync
 DISTVERSION=	3.2.7
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net
 MASTER_SITES=	https://www.mirrorservice.org/sites/rsync.samba.org/src/ \
 		http://rsync.mirror.garr.it/src/ \
@@ -54,6 +54,9 @@ EXTRA_PATCHES+=	files/CVE-2024-12087/0001-Refuse-a-duplicate-dirlist.patch:-p1
 EXTRA_PATCHES+=	files/CVE-2024-12087/0002-range-check-dir_ndx-before-use.patch:-p1
 EXTRA_PATCHES+=	files/CVE-2024-12088/0001-make-safe-links-stricter.patch:-p1
 EXTRA_PATCHES+=	files/CVE-2024-12747/0001-fixed-symlink-race-condition-in-sender.patch:-p1
+EXTRA_PATCHES+=	files/raise-protocol-version-to-32.patch:-p1
+EXTRA_PATCHES+=	files/Fix_use-after-free_in_generator.patch:-p1
+EXTRA_PATCHES+=	files/Fix-FLAG_GOT_DIR_FLIST-collission-with-FLAG_HLINKED.patch:-p1
 
 PORTDOCS=	NEWS.md README.md csprotocol.txt tech_report.tex
 

--- a/net/rsync/files/Fix-FLAG_GOT_DIR_FLIST-collission-with-FLAG_HLINKED.patch
+++ b/net/rsync/files/Fix-FLAG_GOT_DIR_FLIST-collission-with-FLAG_HLINKED.patch
@@ -1,0 +1,40 @@
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Wed, 15 Jan 2025 15:10:24 +0100
+Subject: Fix FLAG_GOT_DIR_FLIST collission with FLAG_HLINKED
+Origin: https://github.com/ncopa/rsync/commit/efb85fd8db9e8f74eb3ab91ebf44f6ed35e3da5b
+Bug: https://github.com/RsyncProject/rsync/issues/697
+Bug-Debian: https://bugs.debian.org/1093089
+Bug-Debian: https://bugs.debian.org/1093052
+Bug: https://github.com/RsyncProject/rsync/issues/702
+
+fixes commit 688f5c379a43 (Refuse a duplicate dirlist.)
+
+Fixes: https://github.com/RsyncProject/rsync/issues/702
+Fixes: https://github.com/RsyncProject/rsync/issues/697
+---
+ rsync.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rsync.h b/rsync.h
+index 9be1297bdd29..479ac4848991 100644
+--- a/rsync.h
++++ b/rsync.h
+@@ -84,7 +84,6 @@
+ #define FLAG_DUPLICATE (1<<4)	/* sender */
+ #define FLAG_MISSING_DIR (1<<4)	/* generator */
+ #define FLAG_HLINKED (1<<5)	/* receiver/generator (checked on all types) */
+-#define FLAG_GOT_DIR_FLIST (1<<5)/* sender/receiver/generator - dir_flist only */
+ #define FLAG_HLINK_FIRST (1<<6)	/* receiver/generator (w/FLAG_HLINKED) */
+ #define FLAG_IMPLIED_DIR (1<<6)	/* sender/receiver/generator (dirs only) */
+ #define FLAG_HLINK_LAST (1<<7)	/* receiver/generator */
+@@ -93,6 +92,7 @@
+ #define FLAG_SKIP_GROUP (1<<10)	/* receiver/generator */
+ #define FLAG_TIME_FAILED (1<<11)/* generator */
+ #define FLAG_MOD_NSEC (1<<12)	/* sender/receiver/generator */
++#define FLAG_GOT_DIR_FLIST (1<<13)/* sender/receiver/generator - dir_flist only */
+ 
+ /* These flags are passed to functions but not stored. */
+ 
+-- 
+2.47.1
+

--- a/net/rsync/files/Fix_use-after-free_in_generator.patch
+++ b/net/rsync/files/Fix_use-after-free_in_generator.patch
@@ -1,0 +1,31 @@
+From f923b19fd85039a2b0e908391074872334646d51 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Wed, 15 Jan 2025 15:48:04 +0100
+Subject: [PATCH] Fix use-after-free in generator
+
+full_fname() will free the return value in the next call so we need to
+duplicate it before passing it to rsyserr.
+
+Fixes: https://github.com/RsyncProject/rsync/issues/704
+---
+ generator.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/generator.c b/generator.c
+index 3f13bb95..b56fa569 100644
+--- a/generator.c
++++ b/generator.c
+@@ -2041,8 +2041,12 @@ int atomic_create(struct file_struct *file, char *fname, const char *slnk, const
+ 
+ 	if (!skip_atomic) {
+ 		if (do_rename(tmpname, fname) < 0) {
++			char *full_tmpname = strdup(full_fname(tmpname));
++			if (full_tmpname == NULL)
++				out_of_memory("atomic_create");
+ 			rsyserr(FERROR_XFER, errno, "rename %s -> \"%s\" failed",
+-				full_fname(tmpname), full_fname(fname));
++				full_tmpname, full_fname(fname));
++			free(full_tmpname);
+ 			do_unlink(tmpname);
+ 			return 0;
+ 		}

--- a/net/rsync/files/raise-protocol-version-to-32.patch
+++ b/net/rsync/files/raise-protocol-version-to-32.patch
@@ -1,0 +1,26 @@
+From 163e05b1680c4a3b448fa68d03c3fca9589f3bc4 Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Tue, 10 Dec 2024 13:34:01 +1100
+Subject: [PATCH 1/3] raise protocol version to 32
+
+make it easier to spot unpatched servers
+---
+ rsync.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rsync.h b/rsync.h
+index b9a7101a..9be1297b 100644
+--- a/rsync.h
++++ b/rsync.h
+@@ -111,7 +111,7 @@
+ 
+ /* Update this if you make incompatible changes and ALSO update the
+  * SUBPROTOCOL_VERSION if it is not a final (official) release. */
+-#define PROTOCOL_VERSION 31
++#define PROTOCOL_VERSION 32
+ 
+ /* This is used when working on a new protocol version or for any unofficial
+  * protocol tweaks.  It should be a non-zero value for each pre-release repo
+-- 
+2.34.1
+


### PR DESCRIPTION
This commit fixes defects found upstream in the recent rsync CVE fixes and brings the TrueNAS rsync port in line with debian 3.2.7-1+deb12u2.