### PR TITLE
Sync sysutils/arcconf makefile with 13.3

### DIFF
--- a/sysutils/arcconf/Makefile
+++ b/sysutils/arcconf/Makefile
@@ -1,5 +1,3 @@
-# Created by: michael@fuckner.net
-
 PORTNAME=	arcconf
 DISTVERSION=	4.17.00.${BUILD}
 PORTEPOCH=	1
@@ -9,6 +7,7 @@ DISTNAME=	arcconf_B${BUILD}
 
 MAINTAINER=	michael@fuckner.net
 COMMENT=	Adaptec SCSI/SAS RAID administration tool
+WWW=		https://storage.microsemi.com/en-us/support/
 
 LICENSE=	Microsemi
 LICENSE_NAME=	Microsemi License
@@ -16,6 +15,7 @@ LICENSE_FILE=	${WRKSRC}/freebsd${DIST_TYPE}/cmdline/License.txt
 LICENSE_PERMS=	no-pkg-sell no-dist-sell no-dist-mirror auto-accept
 
 ONLY_FOR_ARCHS=	amd64
+ONLY_FOR_ARCH_REASON=	precompiled binary
 LIB_DEPENDS=	libstdc++.so.6:lang/gcc${GCC_DEFAULT}
 
 USES=		zip
@@ -26,13 +26,7 @@ SUB_FILES+=	${PERIODICSCRIPT}
 
 PERIODICSCRIPT=	410.status-aac-raid
 
-DIST_TYPE=	12_x64
-
-.include <bsd.port.pre.mk>
-
-.if ${OSVERSION} > 1300078
-RUN_DEPENDS+=	${LOCALBASE}/lib/compat/libncurses.so.8:misc/compat12x
-.endif
+DIST_TYPE=	13_x86_64
 
 NO_BUILD=	yes
 NO_WRKSUBDIR=	yes
@@ -45,4 +39,4 @@ do-install:
 	@${MKDIR} ${STAGEDIR}${PREFIX}/etc/periodic/daily
 	${INSTALL_SCRIPT} ${WRKDIR}/${PERIODICSCRIPT} ${STAGEDIR}${PREFIX}/etc/periodic/daily
 
-.include <bsd.port.post.mk>
+.include <bsd.port.mk>

--- a/sysutils/arcconf/pkg-descr
+++ b/sysutils/arcconf/pkg-descr
@@ -1,4 +1,2 @@
 Command Line Interface for the Adaptec SCSI RAID family of RAID controllers,
 used to configure and manage connected storage devices.
-
-WWW: https://storage.microsemi.com/en-us/support/


### PR DESCRIPTION
This commit syncs up the makefile in the arcconf port with what we have in 13.3 ports.